### PR TITLE
change: re-organize config and make descriptions better, new: dont hide important npcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,5 +192,5 @@ Enter the Hytilities directory. From here, what you do depends on your OS. This 
 
 Type `./gradlew setupDecompWorkspace`. This may take several minutes. It should say `BUILD SUCCESSFUL` once finished.
 
-Now, you can edit the files as you would any other project, such as with a Terminal editor like vim. To compile, run `./gradlew build`. They will be in the `versions/1.8.9/build/libs` folder. To launch the game, run `./gradlew runClient`.
+Now, you can edit the files as you would any other project, such as with a Terminal editor like vim. To compile, run `./gradlew build`. They will be in the `build/libs` folder. To launch the game, run `./gradlew runClient`.
 </details>

--- a/src/main/java/net/wyvest/hytilities/config/HytilitiesConfig.java
+++ b/src/main/java/net/wyvest/hytilities/config/HytilitiesConfig.java
@@ -28,6 +28,142 @@ import java.io.File;
 
 public class HytilitiesConfig extends Vigilant {
 
+    // API
+
+    @Property(
+        type = PropertyType.TEXT, name = "API Key",
+        description = "The API Key, for some features that require accessing to the Hypixel API such as the Auto GEXP and winstreak features.",
+        category = "API",
+        protectedText = true
+    )
+    public static String apiKey = "";
+
+    // Automatic
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Automatically Get API Key",
+        description = "Automatically get the API Key from /api new.",
+        category = "Automatic", subcategory = "API"
+    )
+    public static boolean autoGetAPI = true;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Auto Start",
+        description = "Join Hypixel immediately once the client has loaded to the main menu.",
+        category = "Automatic", subcategory = "General"
+    )
+    public static boolean autoStart;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Auto Queue",
+        description = "Automatically queues for another game once you die.\n§eThis will require you to interact with the game in a way to prevent abuse.",
+        category = "Automatic", subcategory = "Game"
+    )
+    public static boolean autoQueue;
+
+    @Property(
+        type = PropertyType.SLIDER, name = "Auto Queue Delay",
+        description = "Delays the execution of Auto Queue.\n§eMeasured in seconds.",
+        category = "Automatic", subcategory = "Game",
+        max = 10
+    )
+    public static int autoQueueDelay;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Auto-Complete Play Commands",
+        description = "Allows tab completion of /play commands.",
+        category = "Automatic", subcategory = "Game"
+    )
+    public static boolean autocompletePlayCommands;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Limbo Play Helper",
+        description = "When a /play command is run in Limbo, this runs /l first and then the command.",
+        category = "Automatic", subcategory = "Game"
+    )
+    public static boolean limboPlayCommandHelper;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Auto GL",
+        description = "Send a message 5 seconds before a Hypixel game starts.",
+        category = "Automatic", subcategory = "AutoGL"
+    )
+    public static boolean autoGL = false;
+
+    @Property(
+        type = PropertyType.SELECTOR, name = "Auto GL Phrase",
+        description = "Choose what message is said.",
+        category = "Automatic", subcategory = "AutoGL",
+        options = {"glhf", "Good Luck", "GL", "Have a good game!", "gl", "Good luck!"}
+    )
+    public static int glPhrase = 0;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Anti-GL",
+        description = "Remove all GL messages from chat.",
+        category = "Automatic", subcategory = "AutoGL"
+    )
+    public static boolean antiGL = false;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Automatically Check GEXP",
+        description = "Automatically check your GEXP after you win a Hypixel game.\n§4Requires an API Key.",
+        category = "Automatic", subcategory = "Stats"
+    )
+    public static boolean autoGetGEXP = false;
+
+    @Property(
+        type = PropertyType.SELECTOR, name = "GEXP Mode",
+        description = "Choose which GEXP to get.",
+        category = "Automatic", subcategory = "Stats",
+        options = {"Daily", "Weekly"}
+    )
+    public static int gexpMode = 0;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Automatically Check Winstreak",
+        description = "Automatically check your winstreak after you win a Hypixel game.\n§4Requires an API Key.",
+        category = "Automatic", subcategory = "Stats"
+    )
+    public static boolean autoGetWinstreak = false;
+
+    // Chat
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Remove Lobby Statuses",
+        description = "Remove lobby join messages from chat.\n§eExample: §b[MVP§c+§b] Steve §6joined the lobby!",
+        category = "Chat", subcategory = "Toggles"
+    )
+    public static boolean lobbyStatus;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Remover others Mystery Box Rewards",
+        description = "Remove others mystery box messages from chat and only show your own.\n§eExample: §b[Mystery Box] Steve §ffound a §6Legendary Hype Train Gadget§f!",
+        category = "Chat", subcategory = "Toggles"
+    )
+    public static boolean mysteryBoxAnnouncer;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Remove Soul Well Announcements",
+        description = "Remove soul well announcements from chat.\n§eExample: §bSteve §7has found a §6Bulldozer Perk I (Insane) §7in the §bSoul Well§7!",
+        category = "Chat", subcategory = "Toggles"
+    )
+    public static boolean soulWellAnnouncer;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Remove Game Announcements",
+        description = "Remove game announcements from chat.\n§eExample: §b➤ A §e§lMega Skywars §bgame is available to join! §6§lCLICK HERE §bto join!",
+        category = "Chat", subcategory = "Toggles"
+    )
+    public static boolean gameAnnouncements;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Remove Hype Limit Reminder",
+        description = "Remove Hype limit reminders from chat.\n§eExample: §f➤ §6You have reached your Hype limit...",
+        category = "Chat", subcategory = "Toggles"
+    )
+    public static boolean hypeLimitReminder;
+
     @Property(
         type = PropertyType.SWITCH, name = "Player AdBlocker",
         description = "Remove spam messages from players, usually advertising something.",
@@ -36,64 +172,15 @@ public class HytilitiesConfig extends Vigilant {
     public static boolean playerAdBlock;
 
     @Property(
-        type = PropertyType.SWITCH, name = "Trim Line Separators",
-        description = "Prevent separators from overflowing onto the next chat line.",
-        category = "Chat", subcategory = "Toggles"
-    )
-    public static boolean lineBreakerTrim = true;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Remove Lobby Statuses",
-        description = "Remove lobby join messages from chat.",
-        category = "Chat", subcategory = "Toggles"
-    )
-    public static boolean lobbyStatus;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Limbo Play Helper",
-        description = "When a /play command is run in Limbo, this runs /l first and then the command.",
-        category = "Chat", subcategory = "Toggles"
-    )
-    public static boolean limboPlayCommandHelper;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Show Personal Mystery Box Rewards",
-        description = "Remove others mystery box messages from chat.",
-        category = "Chat", subcategory = "Toggles"
-    )
-    public static boolean mysteryBoxAnnouncer;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Remove Soul Well Announcements",
-        description = "Remove soul well announcements from chat.",
-        category = "Chat", subcategory = "Toggles"
-    )
-    public static boolean soulWellAnnouncer;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Remove Game Announcements",
-        description = "Remove game announcements from chat.",
-        category = "Chat", subcategory = "Toggles"
-    )
-    public static boolean gameAnnouncements;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Remove Hype Limit Reminder",
-        description = "Remove Hype limit reminders from chat.",
-        category = "Chat", subcategory = "Toggles"
-    )
-    public static boolean hypeLimitReminder;
-
-    @Property(
         type = PropertyType.SWITCH, name = "Remove BedWars Advertisements",
-        description = "Remove player messages asking to join BedWars parties.",
+        description = "Remove player messages asking to join BedWars parties.\n§eExample: §7[1✫] §b[MVP§c+§b] Steve§f: Join BedWars party!",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean bedwarsAdvertisements;
 
     @Property(
         type = PropertyType.SWITCH, name = "Remove Friend/Guild Statuses",
-        description = "Remove join/quit messages from friend/guild members.",
+        description = "Remove join/quit messages from friend/guild members.\n§eExample: §aFriend > §bSteve §ejoined.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean connectionStatus;
@@ -107,14 +194,14 @@ public class HytilitiesConfig extends Vigilant {
 
     @Property(
         type = PropertyType.SWITCH, name = "Remove Chat Emojis",
-        description = "Remove MVP++ chat emojis.",
+        description = "Remove MVP++ chat emojis.\n§eExample: §c§lOOF",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean mvpEmotes;
 
     @Property(
         type = PropertyType.SWITCH, name = "Remove Server Connected Messages",
-        description = "Remove messages informing you of the lobby name you've just joined, or what lobby you're being sent to.",
+        description = "Remove messages informing you of the lobby name you've just joined, or what lobby you're being sent to.\n§eExample: §bYou are currently connected to server §6mini104H§b.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean serverConnectedMessages;
@@ -127,153 +214,102 @@ public class HytilitiesConfig extends Vigilant {
     public static boolean questsMessages;
 
     @Property(
-        type = PropertyType.SWITCH, name = "White Chat",
-        description = "Make nons chat messages appear as the normal chat message color.",
+        type = PropertyType.SWITCH, name = "Remove Curse of Spam Messages",
+        description = "Hides the constant spam of Kali's curse of spam.\n§eExample: §eKALI HAS STRIKEN YOU WITH THE CURSE OF SPAM",
         category = "Chat", subcategory = "Toggles"
+    )
+    public static boolean curseOfSpam;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Remove the Skyblock Welcome Message",
+        description = "Hides the \"§eWelcome to §aHypixel SkyBlock§e!§r\" from chat.",
+        category = "Chat", subcategory = "Toggles"
+    )
+    public static boolean skyblockWelcome;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Remove Gifts Message",
+        description = "Removes \"They have gifted x so far!\" messages from chat.",
+        category = "Chat", subcategory = "Toggles"
+    )
+    public static boolean giftBlocker;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Remove Grinch Gifts Messages",
+        description = "Removes personal and global gifts collected messages from chat.\n§eExamples:\n§aYou found a gift! §7(5 total)\n§b[MVP§c+§b] Steve§f §ehas reached §c20 §egifts!",
+        category = "Chat", subcategory = "Toggles"
+    )
+    public static boolean grinchPresents;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Remove Network Booster Perk Messages",
+        description = "Removes the network booster perk messages from chat.\n§eExample: §6+50 coins (Steve's Network Booster)§r",
+        category = "Chat", subcategory = "Toggles"
+    )
+    public static boolean boosterRemover;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Trim Line Separators",
+        description = "Prevent separators from overflowing onto the next chat line.",
+        category = "Chat", subcategory = "Visual"
+    )
+    public static boolean lineBreakerTrim = true;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "White Chat",
+        description = "Make nons chat messages appear as the normal chat message color.\n§eExample: §7Steve: Hey! §e-> §fPlayer: Hey!",
+        category = "Chat", subcategory = "Visual"
     )
     public static boolean whiteChat;
 
     @Property(
         type = PropertyType.SWITCH, name = "White Private Messages",
-        description = "Make private messages appear as the normal chat message color.",
-        category = "Chat", subcategory = "Toggles"
+        description = "Make private messages appear as the normal chat message color.\n§eExample: §dFrom §b[MVP§c+§b] Steve: §7hey! §e-> §dFrom §b[MVP§c+§b] Player: §fhey!",
+        category = "Chat", subcategory = "Visual"
     )
     public static boolean whitePrivateMessages;
 
     @Property(
         type = PropertyType.SWITCH, name = "Cleaner Game Start Counter",
-        description = "Compacts game start announcements.",
-        category = "Chat", subcategory = "Toggles"
+        description = "Compacts game start announcements.\n§eExample: The game starts in 20 seconds!",
+        category = "Chat", subcategory = "Visual"
     )
     public static boolean cleanerGameStartAnnouncements;
 
     @Property(
+        type = PropertyType.SWITCH, name = "Short Channel Names",
+        description = "Abbreviate chat channel names.\n§eExample: §2Guild §e-> §2G§e, §9Party §e-> §9P§e, §dFriend §e-> §dF",
+        category = "Chat", subcategory = "Visual"
+    )
+    public static boolean shortChannelNames;
+
+    @Property(
         type = PropertyType.SWITCH, name = "Game Status Restyle",
-        description = "Replace common game status messages with a new style.",
+        description = "Replace common game status messages with a new style.\n§eExamples:\n§a§l+ §bSteve §e(§b1§e/§b12§e)\n§c§l- §bSteve §e(§b1§e/§b12§e)\n§e§l* §aGame starts in §b§l5 §aseconds.",
         category = "Chat", subcategory = "Restyler"
     )
     public static boolean gameStatusRestyle;
 
     @Property(
         type = PropertyType.SWITCH, name = "Player Count Before Player Name",
-        description = "Put the player count before the player name in game join/leave messages.",
+        description = "Put the player count before the player name in game join/leave messages.\n§eExample: §e(§b1§e/§b12§e) §bSteve §ehas joined!",
         category = "Chat", subcategory = "Restyler"
     )
     public static boolean playerCountBeforePlayerName;
 
     @Property(
         type = PropertyType.SWITCH, name = "Player Count on Player Leave",
-        description = "Include the player count when players leave.",
+        description = "Include the player count when players leave.\n§eExample: §bSteve §ehas quit (§b1§e/§b12§e)!",
         category = "Chat", subcategory = "Restyler"
     )
     public static boolean playerCountOnPlayerLeave;
 
     @Property(
         type = PropertyType.SWITCH, name = "Player Count Padding",
-        description = "Place zeros at the beginning of the player count to align with the max player count.",
+        description = "Place zeros at the beginning of the player count to align with the max player count.\n§eExample: §bSteve §ehas joined §e(§b001§e/§b111§e)!",
         category = "Chat", subcategory = "Restyler"
     )
     public static boolean padPlayerCount;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Short Channel Names",
-        description = "Abbreviate chat channel names.",
-        category = "Chat", subcategory = "Restyler"
-    )
-    public static boolean shortChannelNames;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Hide Lobby NPCs",
-        description = "Hide NPCs in the lobby.",
-        category = "Lobby", subcategory = "Entities"
-    )
-    public static boolean npcHider;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Hide NPCs in Tab",
-        description = "Prevent NPCs from showing up in tab.",
-        category = "General", subcategory = "Entities"
-    )
-    public static boolean hideNpcsInTab;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Hide Guild Tags in Tab",
-        description = "Prevent Guild tags from showing up in tab.",
-        category = "General", subcategory = "Guilds"
-    )
-    public static boolean hideGuildTagsInTab;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Hide Player Ranks in Tab",
-        description = "Prevent player ranks from showing up in tab.",
-        category = "General", subcategory = "General"
-    )
-    public static boolean hidePlayerRanksInTab;
-
-    @Property(
-        type = PropertyType.SELECTOR, name = "Highlight Friends In Tab",
-        description = "Add a star to the names of your Hypixel friends in tab.",
-        category = "General", subcategory = "General",
-        options = {"Off", "Left of Name", "Right of Name"}
-    )
-    public static int highlightFriendsInTab;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Cleaner Tab in Skyblock",
-        description = "Doesn't render player heads or ping for tab entries that aren't players in Skyblock.",
-        category = "General", subcategory = "General"
-    )
-    public static boolean cleanerSkyblockTabInfo;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Hide Ping in Tab",
-        description = "Prevent ping from showing up in tab while playing games, since the value is misleading. Ping will remain visible in lobbies.",
-        category = "General", subcategory = "General"
-    )
-    public static boolean hidePingInTab;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Limbo Limiter",
-        description = "While in Limbo, limit your framerate to reduce the load of the game on your computer.",
-        category = "Lobby", subcategory = "General"
-    )
-    public static boolean limboLimiter;
-
-    @Property(
-        type = PropertyType.SLIDER, name = "Limbo Limiter FPS",
-        description = "While in Limbo, limit your framerate to reduce the load of the game on your computer.",
-        category = "Lobby", subcategory = "General",
-        min = 1, max = 60
-    )
-    public static int limboFPS = 15;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Hide Lobby Bossbars",
-        description = "Hide the bossbar in the lobby.",
-        category = "Lobby", subcategory = "GUI"
-    )
-    public static boolean lobbyBossbar;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Broadcast Achievements",
-        description = "Announce in Guild chat when you get an achievement.",
-        category = "General", subcategory = "Guilds"
-    )
-    public static boolean broadcastAchievements;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Broadcast Levelup",
-        description = "Announce in Guild chat when you level up.",
-        category = "General", subcategory = "Guilds"
-    )
-    public static boolean broadcastLevelup;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Auto Start",
-        description = "Join Hypixel immediately once the client has loaded to the main menu.",
-        category = "General", subcategory = "General"
-    )
-    public static boolean autoStart;
 
     @Property(
         type = PropertyType.SWITCH, name = "Chat Swapper",
@@ -298,19 +334,100 @@ public class HytilitiesConfig extends Vigilant {
     public static int chatSwapperReturnChannel;
 
     @Property(
-        type = PropertyType.SWITCH, name = "Auto Queue",
-        description = "Automatically queues for another game once you die.\n§eThis will require you to interact with the game in a way to prevent abuse.",
-        category = "Automatic"
+        type = PropertyType.SWITCH, name = "Remove All Chat Message",
+        description = "Hide the \"§aYou are now in the §6ALL§a channel§r\" message when auto-switching.",
+        category = "Chat", subcategory = "Parties"
     )
-    public static boolean autoQueue;
+    public static boolean hideAllChatMessage;
 
     @Property(
-        type = PropertyType.SLIDER, name = "Auto Queue Delay",
-        description = "Delays the execution of Auto Queue.\n§eMeasured in seconds.",
-        category = "Automatic",
-        max = 10
+        type = PropertyType.SWITCH, name = "Thank Watchdog",
+        description = "Compliment Watchdog when someone is banned, or a Watchdog announcement is sent.\n§eExample: §fThanks Watchdog!",
+        category = "Chat", subcategory = "Watchdog"
     )
-    public static int autoQueueDelay;
+    public static boolean thankWatchdog;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Auto Chat Report Confirm",
+        description = "Automatically confirms chat reports.",
+        category = "Automatic", subcategory = "Chat"
+    )
+    public static boolean autoChatReportConfirm;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Guild Welcome Message",
+        description = "Send a friendly welcome message when a player joins your guild.\n§eExample: §fWelcome to the guild Steve!",
+        category = "Chat", subcategory = "Guild"
+    )
+    public static boolean guildWelcomeMessage;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Shout Cooldown",
+        description = "Show the amount of time remaining until /shout can be reused.\n§eExample: §eShout command is on cooldown. Please wait 30 more seconds.",
+        category = "Chat", subcategory = "Shout"
+    )
+    public static boolean preventShoutingOnCooldown;
+
+    // General
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Hide NPCs in Tab",
+        description = "Prevent NPCs from showing up in tab.",
+        category = "General", subcategory = "Tab"
+    )
+    public static boolean hideNpcsInTab;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Hide Guild Tags in Tab",
+        description = "Prevent Guild tags from showing up in tab.",
+        category = "General", subcategory = "Tab"
+    )
+    public static boolean hideGuildTagsInTab;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Hide Player Ranks in Tab",
+        description = "Prevent player ranks from showing up in tab.",
+        category = "General", subcategory = "Tab"
+    )
+    public static boolean hidePlayerRanksInTab;
+
+    @Property(
+        type = PropertyType.SELECTOR, name = "Highlight Friends In Tab",
+        description = "Add a star to the names of your Hypixel friends in tab.",
+        category = "General", subcategory = "Tab",
+        options = {"Off", "Left of Name", "Right of Name"}
+    )
+    public static int highlightFriendsInTab;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Cleaner Tab in Skyblock",
+        description = "Doesn't render player heads or ping for tab entries that aren't players in Skyblock.",
+        category = "General", subcategory = "Tab"
+    )
+    public static boolean cleanerSkyblockTabInfo;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Hide Ping in Tab",
+        description = "Prevent ping from showing up in tab while playing games, since the value is misleading. Ping will remain visible in lobbies.",
+        category = "General", subcategory = "Tab"
+    )
+    public static boolean hidePingInTab;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Broadcast Achievements",
+        description = "Announce in Guild chat when you get an achievement.",
+        category = "General", subcategory = "Guilds"
+    )
+    public static boolean broadcastAchievements;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Broadcast Levelup",
+        description = "Announce in Guild chat when you level up.",
+        category = "General", subcategory = "Guilds"
+    )
+    public static boolean broadcastLevelup;
+
+    // Game
 
     @Property(
         type = PropertyType.SWITCH, name = "Highlight Opened Chests",
@@ -362,134 +479,14 @@ public class HytilitiesConfig extends Vigilant {
     public static boolean muteHousingMusic;
 
     @Property(
-        type = PropertyType.SWITCH, name = "Remove All Chat Message",
-        description = "Hide the \"§aYou are now in the §6ALL§a channel§r\" message when auto-switching.",
-        category = "Chat", subcategory = "Parties"
-    )
-    public static boolean hideAllChatMessage;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Thank Watchdog",
-        description = "Compliment Watchdog when someone is banned, or a Watchdog announcement is sent.",
-        category = "Chat", subcategory = "Watchdog"
-    )
-    public static boolean thankWatchdog;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Auto Chat Report Confirm",
-        description = "Automatically confirms chat reports.",
-        category = "Chat", subcategory = "Chat Report"
-    )
-    public static boolean autoChatReportConfirm;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Guild Welcome Message",
-        description = "Send a friendly welcome message when a player joins your guild.",
-        category = "Chat", subcategory = "Guild"
-    )
-    public static boolean guildWelcomeMessage;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Shout Cooldown",
-        description = "Show the amount of time remaining until /shout can be reused.",
-        category = "Chat", subcategory = "Shout"
-    )
-    public static boolean preventShoutingOnCooldown;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Mystery Box Star",
-        description = "Shows what star a mystery box is in the Mystery Box Vault, Orange stars are special boxes.",
-        category = "Lobby", subcategory = "GUI"
-    )
-    public static boolean mysteryBoxStar;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Remove Curse of Spam Messages",
-        description = "Hides the constant spam of Kali's curse of spam.",
-        category = "Chat", subcategory = "Toggles"
-    )
-    public static boolean curseOfSpam;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Remove the Skyblock welcome message",
-        description = "Hides the Skyblock welcome message.",
-        category = "Chat", subcategory = "Toggles"
-    )
-    public static boolean skyblockWelcome;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Auto-Complete Play Commands",
-        description = "Allows tab completion of /play commands.",
-        category = "Chat", subcategory = "AutoComplete"
-    )
-    public static boolean autocompletePlayCommands;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Remove Gifts Message",
-        description = "Removes \"They have gifted x so far!\" messages.",
-        category = "Chat", subcategory = "Toggles"
-    )
-    public static boolean giftBlocker;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Remove Grinch Gifts Messages",
-        description = "Removes personal and global gifts connected messages.",
-        category = "Chat", subcategory = "Toggles"
-    )
-    public static boolean grinchPresents;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Remove Network Booster Perk Messages",
-        description = "Removes network booster perk messages messages.",
-        category = "Chat", subcategory = "Toggles"
-    )
-    public static boolean boosterRemover;
-
-    @Property(
-        type = PropertyType.TEXT, name = "API Key",
-        description = "The API Key, for some features that require accessing to the Hypixel API such as the Auto GEXP and winstreak features.",
-        category = "API"
-    )
-    public static String apiKey = "";
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Automatically Get API Key",
-        description = "Automatically get the API Key from /api new.",
-        category = "Automatic"
-    )
-    public static boolean autoGetAPI = true;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Automatically Check GEXP",
-        description = "Automatically check your GEXP after you win a Hypixel game. \n§4Requires an API Key.",
-        category = "Automatic"
-    )
-    public static boolean autoGetGEXP = false;
-
-    @Property(
-        type = PropertyType.SELECTOR, name = "GEXP Mode",
-        description = "Choose which GEXP to get.",
-        category = "Automatic",
-        options = {"Daily", "Weekly"}
-    )
-    public static int gexpMode = 0;
-
-    @Property(
-        type = PropertyType.SWITCH, name = "Automatically Check Winstreak",
-        description = "Automatically check your winstreak after you win a Hypixel game. \n§4Requires an API Key.",
-        category = "Automatic"
-    )
-    public static boolean autoGetWinstreak = false;
-
-    @Property(
         type = PropertyType.SWITCH, name = "Height Overlay",
-        description = "Make blocks that are in the Hypixel height limit a different colour.\nReloads chunks automatically when toggled on and off.",
+        description = "Make blocks that are in the Hypixel height limit a different colour.\n§4eReloads chunks automatically when toggled on and off.",
         category = "Game", subcategory = "Visual"
     )
     public static boolean heightOverlay = false;
 
     @Property(
-        type = PropertyType.DECIMAL_SLIDER, name = "Overlay Tint Multiplier",
+        type = PropertyType.DECIMAL_SLIDER, name = "Height Overlay Tint Multiplier",
         description = "Adjust the tint multiplier.",
         category = "Game", subcategory = "Visual",
         maxF = 1.0F
@@ -512,7 +509,7 @@ public class HytilitiesConfig extends Vigilant {
     public static int blockNumber = 10;
 
     @Property(
-        type = PropertyType.SELECTOR, name = "Sound",
+        type = PropertyType.SELECTOR, name = "Block Notify Sound",
         description = "Choose what sound to play.",
         category = "Game", subcategory = "Sound",
         options = {"Hypixel Ding", "Golem Hit", "Blaze Hit", "Anvil Land", "Horse Death", "Ghast Scream", "Guardian Floop", "Cat Meow", "Dog Bark"}
@@ -520,7 +517,7 @@ public class HytilitiesConfig extends Vigilant {
     public static int blockNotifySound = 0;
 
     @Property(
-        type = PropertyType.SWITCH, name = "Spam Sound",
+        type = PropertyType.SWITCH, name = "Spam Block Notify Sound",
         description = "Spam the sound (this will make it VERY loud)",
         category = "Game", subcategory = "Sound"
     )
@@ -533,31 +530,66 @@ public class HytilitiesConfig extends Vigilant {
     )
     public static boolean hideDuelsCosmetics = false;
 
-    @Property(
-        type = PropertyType.SWITCH, name = "Auto GL",
-        category = "Chat",
-        description = "Send a message 5 seconds before a Hypixel game starts."
-    )
-    public static boolean autoGL = false;
+    // Lobby
 
     @Property(
-        type = PropertyType.SELECTOR, name = "Auto GL Phrase",
-        category = "Chat",
-        description = "Choose what message is said.",
-        options = {"glhf", "Good Luck", "GL", "Have a good game!", "gl", "Good luck!"}
+        type = PropertyType.SWITCH, name = "Hide Lobby NPCs",
+        description = "Hide NPCs in the lobby.",
+        category = "Lobby", subcategory = "Entities"
     )
-    public static int glPhrase = 0;
+    public static boolean npcHider;
 
     @Property(
-        type = PropertyType.SWITCH, name = "Anti-GL",
-        category = "Chat",
-        description = "Remove all GL messages in chat."
+        type = PropertyType.SWITCH, name = "Limbo Limiter",
+        description = "While in Limbo, limit your framerate to reduce the load of the game on your computer.",
+        category = "Lobby", subcategory = "General"
     )
-    public static boolean antiGL = false;
+    public static boolean limboLimiter;
+
+    @Property(
+        type = PropertyType.SLIDER, name = "Limbo Limiter FPS",
+        description = "While in Limbo, limit your framerate to reduce the load of the game on your computer.",
+        category = "Lobby", subcategory = "General",
+        min = 1, max = 60
+    )
+    public static int limboFPS = 15;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Hide Lobby Bossbars",
+        description = "Hide the bossbar in the lobby.",
+        category = "Lobby", subcategory = "GUI"
+    )
+    public static boolean lobbyBossbar;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Mystery Box Star",
+        description = "Shows what star a mystery box is in the Mystery Box Vault, Orange stars are special boxes.",
+        category = "Lobby", subcategory = "GUI"
+    )
+    public static boolean mysteryBoxStar;
 
     public HytilitiesConfig() {
         super(new File("./config/hytilitiesreborn.toml"));
         initialize();
+
+        addDependency("autoQueueDelay", "autoQueue");
+
+        addDependency("gexpMode", "autoGetGEXP");
+
+        addDependency("antiGL", "autoGL");
+
+        addDependency("playerCountBeforePlayerName", "gameStatusRestyle");
+        addDependency("playerCountOnPlayerLeave", "gameStatusRestyle");
+        addDependency("padPlayerCount", "gameStatusRestyle");
+
+        addDependency("blockNumber", "blockNotify");
+        addDependency("blockNotifySound", "blockNotify");
+        addDependency("blockNotifySound", "blockNotify");
+
+        addDependency("highlightChestsColor", "highlightChests");
+
+        addDependency("overlayAmount", "heightOverlay");
+
         registerListener("heightOverlay", (funny) -> {
             if (funny != null) {
                 heightOverlay = (boolean) funny;

--- a/src/main/java/net/wyvest/hytilities/config/HytilitiesConfig.java
+++ b/src/main/java/net/wyvest/hytilities/config/HytilitiesConfig.java
@@ -378,6 +378,13 @@ public class HytilitiesConfig extends Vigilant {
     public static boolean hideNpcsInTab;
 
     @Property(
+        type = PropertyType.SWITCH, name = "Don't Hide important NPCs",
+        description = "Keeps NPCs in tab in gamemodes like Skyblock and Replay.",
+        category = "General", subcategory = "Tab"
+    )
+    public static boolean keepImportantNpcsInTab;
+
+    @Property(
         type = PropertyType.SWITCH, name = "Hide Guild Tags in Tab",
         description = "Prevent Guild tags from showing up in tab.",
         category = "General", subcategory = "Tab"
@@ -585,6 +592,8 @@ public class HytilitiesConfig extends Vigilant {
         addDependency("blockNumber", "blockNotify");
         addDependency("blockNotifySound", "blockNotify");
         addDependency("blockNotifySound", "blockNotify");
+
+        addDependency("keepImportantNpcsInTab", "hideNpcsInTab");
 
         addDependency("highlightChestsColor", "highlightChests");
 

--- a/src/main/java/net/wyvest/hytilities/config/HytilitiesConfig.java
+++ b/src/main/java/net/wyvest/hytilities/config/HytilitiesConfig.java
@@ -88,7 +88,7 @@ public class HytilitiesConfig extends Vigilant {
         description = "Send a message 5 seconds before a Hypixel game starts.",
         category = "Automatic", subcategory = "AutoGL"
     )
-    public static boolean autoGL = false;
+    public static boolean autoGL;
 
     @Property(
         type = PropertyType.SELECTOR, name = "Auto GL Phrase",
@@ -103,14 +103,14 @@ public class HytilitiesConfig extends Vigilant {
         description = "Remove all GL messages from chat.",
         category = "Automatic", subcategory = "AutoGL"
     )
-    public static boolean antiGL = false;
+    public static boolean antiGL;
 
     @Property(
         type = PropertyType.SWITCH, name = "Automatically Check GEXP",
         description = "Automatically check your GEXP after you win a Hypixel game.\n§4Requires an API Key.",
         category = "Automatic", subcategory = "Stats"
     )
-    public static boolean autoGetGEXP = false;
+    public static boolean autoGetGEXP;
 
     @Property(
         type = PropertyType.SELECTOR, name = "GEXP Mode",
@@ -125,7 +125,7 @@ public class HytilitiesConfig extends Vigilant {
         description = "Automatically check your winstreak after you win a Hypixel game.\n§4Requires an API Key.",
         category = "Automatic", subcategory = "Stats"
     )
-    public static boolean autoGetWinstreak = false;
+    public static boolean autoGetWinstreak;
 
     // Chat
 
@@ -490,7 +490,7 @@ public class HytilitiesConfig extends Vigilant {
         description = "Make blocks that are in the Hypixel height limit a different colour.\n§4eReloads chunks automatically when toggled on and off.",
         category = "Game", subcategory = "Visual"
     )
-    public static boolean heightOverlay = false;
+    public static boolean heightOverlay;
 
     @Property(
         type = PropertyType.DECIMAL_SLIDER, name = "Height Overlay Tint Multiplier",
@@ -505,7 +505,7 @@ public class HytilitiesConfig extends Vigilant {
         description = "Pings you via a sound when your blocks are running out.",
         category = "Game", subcategory = "Sound"
     )
-    public static boolean blockNotify = false;
+    public static boolean blockNotify;
 
     @Property(
         type = PropertyType.NUMBER, name = "Block Number",
@@ -528,14 +528,14 @@ public class HytilitiesConfig extends Vigilant {
         description = "Spam the sound (this will make it VERY loud)",
         category = "Game", subcategory = "Sound"
     )
-    public static boolean spamBlockNotify = false;
+    public static boolean spamBlockNotify;
 
     @Property(
         type = PropertyType.SWITCH, name = "Hide Duels Cosmetics",
         description = "Hide Duels Cosmetics in Hypixel.",
         category = "Game", subcategory = "Visual"
     )
-    public static boolean hideDuelsCosmetics = false;
+    public static boolean hideDuelsCosmetics;
 
     // Lobby
 

--- a/src/main/java/net/wyvest/hytilities/handlers/game/GameType.java
+++ b/src/main/java/net/wyvest/hytilities/handlers/game/GameType.java
@@ -39,7 +39,8 @@ public enum GameType {
     BLITZ_SG("SURVIVAL_GAMES"),
     MEGA_WALLS("WALLS3"),
     SMASH_HEROES("SUPER_SMASH"),
-    WARLORDS("BATTLEGROUND");
+    WARLORDS("BATTLEGROUND"),
+    REPLAY("REPLAY");
 
     private final String serverName;
     private static final GameType[] typeArray = values();

--- a/src/main/java/net/wyvest/hytilities/handlers/lobby/npc/NPCHider.java
+++ b/src/main/java/net/wyvest/hytilities/handlers/lobby/npc/NPCHider.java
@@ -28,6 +28,8 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.passive.EntityVillager;
 import net.minecraftforge.client.event.RenderLivingEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.wyvest.hytilities.handlers.game.GameType;
+import net.wyvest.hytilities.util.locraw.LocrawInformation;
 import org.objectweb.asm.tree.ClassNode;
 
 import java.util.Collection;
@@ -51,10 +53,14 @@ public class NPCHider {
      */
     @SuppressWarnings("unused")
     public static Collection<NetworkPlayerInfo> hideTabNpcs(Collection<NetworkPlayerInfo> playerInfoCollection) {
+        LocrawInformation locraw = Hytilities.INSTANCE.getLocrawUtil().getLocrawInformation();
         if (!EssentialAPI.getMinecraftUtil().isHypixel() || !HytilitiesConfig.hideNpcsInTab) {
-            return playerInfoCollection;
+            if (!HytilitiesConfig.keepImportantNpcsInTab && (locraw == null || locraw.getGameType() == GameType.SKYBLOCK || locraw.getGameType() == GameType.REPLAY)) {
+                return playerInfoCollection;
+            }
         } else {
             return Collections2.filter(playerInfoCollection, player -> player != null && player.getGameProfile().getId().version() != 2);
         }
+        return playerInfoCollection;
     }
 }


### PR DESCRIPTION
lots of reorganizing and stuff. as it was, the hytils config was just a pain to browse through imo. this attempts to better break up the bigger clunks of subcategories and group up options that make more sense to be together. this should not only help users using the mod, but anyone reading the source

knowing me and even seeing my previous commits, i tend to make a lot of mistakes, so please proofread this and give suggestions

some notes:

- im personally not a big fan of the "automatic" section as it is, there are still automatic features in the other categories but it doesnt make sense to move them. might be misleading idk

- some more things could be dependencied

- some of my subcategory names arent the greatest

- for the dont hide important npcs option, i noticed when testing that i could still see npcs in lobby tab sometimes for a few seconds but that was with and without my changes so idk whats going on there

- other stuff that i might add here later if i remember