### PR TITLE
Waypoints and Chat Toggles

### DIFF
--- a/src/main/java/cc/woverflow/hytils/HytilsReborn.java
+++ b/src/main/java/cc/woverflow/hytils/HytilsReborn.java
@@ -21,6 +21,8 @@ package cc.woverflow.hytils;
 import cc.woverflow.hytils.command.*;
 import cc.woverflow.hytils.config.HytilsConfig;
 import cc.woverflow.hytils.handlers.chat.modules.triggers.AutoWB;
+import cc.woverflow.hytils.handlers.game.miniwalls.MiddleBeaconMiniWalls;
+import cc.woverflow.hytils.handlers.game.uhc.MiddleWaypointUHC;
 import cc.woverflow.hytils.handlers.general.AutoStart;
 import cc.woverflow.hytils.handlers.general.CommandQueue;
 import cc.woverflow.hytils.handlers.general.SoundHandler;
@@ -77,7 +79,6 @@ import java.nio.charset.StandardCharsets;
     version = HytilsReborn.VERSION
 )
 public class HytilsReborn {
-
     public static final String MOD_ID = "@ID@";
     public static final String MOD_NAME = "@NAME@";
     public static final String VERSION = "@VER@";
@@ -194,6 +195,8 @@ public class HytilsReborn {
         eventBus.register(new HousingMusic());
         eventBus.register(new GameStartingTitles());
         eventBus.register(new GoalArmorStands());
+        eventBus.register(new MiddleBeaconMiniWalls());
+        eventBus.register(new MiddleWaypointUHC());
 
         // height overlay
         eventBus.register(HeightHandler.INSTANCE);

--- a/src/main/java/cc/woverflow/hytils/HytilsReborn.java
+++ b/src/main/java/cc/woverflow/hytils/HytilsReborn.java
@@ -21,6 +21,7 @@ package cc.woverflow.hytils;
 import cc.woverflow.hytils.command.*;
 import cc.woverflow.hytils.config.HytilsConfig;
 import cc.woverflow.hytils.handlers.chat.modules.triggers.AutoWB;
+import cc.woverflow.hytils.handlers.game.duels.SumoRenderDistance;
 import cc.woverflow.hytils.handlers.game.miniwalls.MiddleBeaconMiniWalls;
 import cc.woverflow.hytils.handlers.game.uhc.MiddleWaypointUHC;
 import cc.woverflow.hytils.handlers.general.AutoStart;
@@ -196,6 +197,7 @@ public class HytilsReborn {
         eventBus.register(new HousingMusic());
         eventBus.register(new GameStartingTitles());
         eventBus.register(new GoalArmorStands());
+        eventBus.register(new SumoRenderDistance());
         eventBus.register(new MiddleBeaconMiniWalls());
         eventBus.register(new MiddleWaypointUHC());
 

--- a/src/main/java/cc/woverflow/hytils/HytilsReborn.java
+++ b/src/main/java/cc/woverflow/hytils/HytilsReborn.java
@@ -197,7 +197,7 @@ public class HytilsReborn {
         eventBus.register(new HousingMusic());
         eventBus.register(new GameStartingTitles());
         eventBus.register(new GoalArmorStands());
-        eventBus.register(new SumoRenderDistance());
+        // eventBus.register(new SumoRenderDistance());
         eventBus.register(new MiddleBeaconMiniWalls());
         eventBus.register(new MiddleWaypointUHC());
 

--- a/src/main/java/cc/woverflow/hytils/HytilsReborn.java
+++ b/src/main/java/cc/woverflow/hytils/HytilsReborn.java
@@ -140,6 +140,7 @@ public class HytilsReborn {
         final ClientCommandHandler commandRegister = ClientCommandHandler.instance;
         commandRegister.registerCommand(new PlayCommand());
         commandRegister.registerCommand(new SilentRemoveCommand());
+        commandRegister.registerCommand(new LimboCommand());
         CosmeticsHandler.INSTANCE.initialize();
         PatternHandler.INSTANCE.initialize();
         HeightHandler.INSTANCE.initialize();

--- a/src/main/java/cc/woverflow/hytils/command/LimboCommand.java
+++ b/src/main/java/cc/woverflow/hytils/command/LimboCommand.java
@@ -1,0 +1,49 @@
+/*
+ * Hytils Reborn - Hypixel focused Quality of Life mod.
+ * Copyright (C) 2022  W-OVERFLOW
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package cc.woverflow.hytils.command;
+
+import cc.woverflow.hytils.HytilsReborn;
+import gg.essential.api.EssentialAPI;
+import net.minecraft.client.Minecraft;
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+
+public class LimboCommand extends CommandBase {
+    @Override
+    public String getCommandName() {
+        return "limbo";
+    }
+
+    @Override
+    public String getCommandUsage(ICommandSender sender) {
+        return "/limbo";
+    }
+
+    // TODO: take precedence over AutoTip, remove the Hypixel error messages created in chat
+    @Override
+    public void processCommand(ICommandSender sender, String[] args) {
+        if (EssentialAPI.getMinecraftUtil().isHypixel()) Minecraft.getMinecraft().thePlayer.sendChatMessage("§");
+    }
+
+    @Override
+    public int getRequiredPermissionLevel() {
+        return -1;
+    }
+}

--- a/src/main/java/cc/woverflow/hytils/command/LimboCommand.java
+++ b/src/main/java/cc/woverflow/hytils/command/LimboCommand.java
@@ -18,11 +18,9 @@
 
 package cc.woverflow.hytils.command;
 
-import cc.woverflow.hytils.HytilsReborn;
 import gg.essential.api.EssentialAPI;
 import net.minecraft.client.Minecraft;
 import net.minecraft.command.CommandBase;
-import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
 
 public class LimboCommand extends CommandBase {

--- a/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
+++ b/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
@@ -279,21 +279,42 @@ public class HytilsConfig extends Vigilant {
         description = "Removes the network booster perk messages from chat.\n§eExample: §6+50 coins (Steve's Network Booster)",
         category = "Chat", subcategory = "Toggles"
     )
-    public static boolean boosterRemover;
+    public static boolean boosterPerk;
 
     @Property(
-        type = PropertyType.SWITCH, name = "Remove Time Played Messages",
-        description = "Removes the time played messages from chat.\n§eExamples:\n§b+25 Bed Wars Experience (Time Played)\n§6+10 coins! (Time Played)",
+        type = PropertyType.SWITCH, name = "Remove Earned Coins and Experience Messages",
+        description = "Removes the earned coins and experience messages from chat.\n§eExamples:\n§b+25 Bed Wars Experience\n§6+10 coins!",
         category = "Chat", subcategory = "Toggles"
     )
-    public static boolean timePlayedRemover;
+    public static boolean earnedCoinsAndExp;
 
     @Property(
-        type = PropertyType.SWITCH, name = "Remove GEXP Messages",
-        description = "Removes the GEXP messages from chat.\n§eExample: §aYou earned §r§2100 GEXP §r§afrom playing SkyBlock!",
+        type = PropertyType.SWITCH, name = "Remove Replay Messages",
+        description = "Removes replay messages from chat.\n§eExample: §4Please add me.",
         category = "Chat", subcategory = "Toggles"
     )
-    public static boolean gexpRemover;
+    public static boolean replayMessage;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Remove Tip Messages",
+        description = "Removes tip messages from chat.\n§eExample: §4Please add me.",
+        category = "Chat", subcategory = "Toggles"
+    )
+    public static boolean tipMessage;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Remove Sending Commands Too Fast Messages",
+        description = "Removes the sending commands messages from chat.\n§eExample: §4Please add me.",
+        category = "Chat", subcategory = "Toggles"
+    )
+    public static boolean sendingCommands;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Remove Online Status Messages",
+        description = "Removes the online status messages from chat.\n§eExample: §6§lREMINDER: §r§6Your Online Status is currently set to §r§e§lAppear Offline§r",
+        category = "Chat", subcategory = "Toggles"
+    )
+    public static boolean onlineStatus;
 
     @Property(
         type = PropertyType.SWITCH, name = "Trim Line Separators",
@@ -330,6 +351,7 @@ public class HytilsConfig extends Vigilant {
     )
     public static boolean coloredStatuses;
 
+    // TODO: add support for Murder Mystery (eg: The alpha infected will be chosen in 5 seconds!)
     @Property(
         type = PropertyType.SWITCH, name = "Cleaner Game Start Counter",
         description = "Compacts game start announcements.\n§eExample: The game starts in 20 seconds!",

--- a/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
+++ b/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
@@ -693,6 +693,20 @@ public class HytilsConfig extends Vigilant {
     public static float uhcOverlayMultiplier = 1f;
 
     @Property(
+        type = PropertyType.SWITCH, name = "UHC Middle Waypoint",
+        description = "Adds a waypoint to signify (0,0).",
+        category = "Game", subcategory = "Visual"
+    )
+    public static boolean uhcMiddleWaypoint;
+
+    @Property(
+        type = PropertyType.TEXT, name = "UHC Middle Waypoint Text",
+        description = "Text on waypoint.",
+        category = "Game", subcategory = "Visual"
+    )
+    public static String uhcMiddleWaypointText = "0,0";
+
+    @Property(
         type = PropertyType.SWITCH, name = "Hide Armor",
         description = "Hide armor in games where armor is always the same.",
         category = "Game", subcategory = "Visual"
@@ -791,11 +805,18 @@ public class HytilsConfig extends Vigilant {
     public static boolean hideNonNPCs;
 
     @Property(
-        type = PropertyType.SWITCH, name = "Middle Waypoint in MiniWalls",
-        description = "Adds a waypoint for the 0 0 coordinates when your MiniWither is dead in MiniWalls.",
+        type = PropertyType.SWITCH, name = "Middle Waypoint Beacon in MiniWalls",
+        description = "Adds a beacon at (0,0) when your MiniWither is dead in MiniWalls.",
         category = "Game", subcategory = "Visual"
     )
-    public static boolean miniWallsMiddleWaypoint;
+    public static boolean miniWallsMiddleBeacon;
+
+    @Property(
+        type = PropertyType.COLOR, name = "Middle Waypoint Beacon in MiniWalls",
+        description = "Set the color of the beacon.",
+        category = "Game", subcategory = "Visual"
+    )
+    public static Color miniWallsMiddleBeaconColor = Color.BLUE;
 
     @Property(
         type = PropertyType.SWITCH, name = "Mute Housing Music",

--- a/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
+++ b/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
@@ -219,11 +219,25 @@ public class HytilsConfig extends Vigilant {
     public static boolean serverConnectedMessages;
 
     @Property(
+        type = PropertyType.SWITCH, name = "Remove Game Tips Messages",
+        description = "Remove tips about the game you are playing.\n§eExample: §4Please add me.",
+        category = "Chat", subcategory = "Toggles"
+    )
+    public static boolean gameTipMessages;
+
+    @Property(
         type = PropertyType.SWITCH, name = "Remove Auto Activated Quest Messages",
         description = "Remove automatically activated quest messages.\n§eExample: §aAutomatically activated: §6Daily Quest: Duels Winner",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean questsMessages;
+
+    @Property(
+        type = PropertyType.SWITCH, name = "Remove Stats Messages",
+        description = "Remove the \"view your stats\" messages.\n§eExample: §4Please add me.",
+        category = "Chat", subcategory = "Toggles"
+    )
+    public static boolean statsMessages;
 
     @Property(
         type = PropertyType.SWITCH, name = "Remove Curse of Spam Messages",
@@ -283,28 +297,21 @@ public class HytilsConfig extends Vigilant {
 
     @Property(
         type = PropertyType.SWITCH, name = "Remove Replay Messages",
-        description = "Removes replay messages from chat.\n§eExample: §4Please add me.",
+        description = "Removes replay messages from chat.\n§eExample: §6§aThis game has been recorded. §6Click here to watch the Replay!",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean replayMessage;
 
     @Property(
         type = PropertyType.SWITCH, name = "Remove Tip Messages",
-        description = "Removes tip messages from chat.\n§eExample: §4Please add me.",
+        description = "Removes tip messages from chat.\n§eExample: §a§aYou tipped 5 players in 10 different games!",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean tipMessage;
 
     @Property(
-        type = PropertyType.SWITCH, name = "Remove Sending Commands Too Fast Messages",
-        description = "Removes the sending commands messages from chat.\n§eExample: §4Please add me.",
-        category = "Chat", subcategory = "Toggles"
-    )
-    public static boolean sendingCommands;
-
-    @Property(
         type = PropertyType.SWITCH, name = "Remove Online Status Messages",
-        description = "Removes the online status messages from chat.\n§eExample: §6§lREMINDER: §r§6Your Online Status is currently set to §r§e§lAppear Offline§r",
+        description = "Removes the online status messages from chat.\n§eExample: §6§lREMINDER: §r§6Your Online Status is currently set to §r§e§lAppear Offline",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean onlineStatus;

--- a/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
+++ b/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
@@ -729,6 +729,21 @@ public class HytilsConfig extends Vigilant {
     public static String uhcMiddleWaypointText = "0,0";
 
     @Property(
+        type = PropertyType.SWITCH, name = "Lower Render Distance in Sumo",
+        description = "Lowers render distance to your desired value in sumo duels.",
+        category = "Game", subcategory = "Visual"
+    )
+    public static boolean sumoRenderDistance;
+
+    @Property(
+        type = PropertyType.SLIDER, name = "Sumo Render Distance",
+        description = "Choose your render distance.",
+        category = "Game", subcategory = "Visual",
+        min = 1, max = 5
+    )
+    public static int sumoRenderDistanceAmount = 2;
+
+    @Property(
         type = PropertyType.SWITCH, name = "Hide Armor",
         description = "Hide armor in games where armor is always the same.",
         category = "Game", subcategory = "Visual"
@@ -976,6 +991,10 @@ public class HytilsConfig extends Vigilant {
         addDependency("highlightChestsColor", "highlightChests");
 
         addDependency("uhcOverlayMultiplier", "uhcOverlay");
+
+        addDependency("uhcMiddleWaypointText", "uhcMiddleWaypoint");
+
+        addDependency("sumoRenderDistanceAmount", "sumoRenderDistance");
 
         addDependency("overlayAmount", "heightOverlay");
 

--- a/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
+++ b/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
@@ -275,13 +275,6 @@ public class HytilsConfig extends Vigilant {
     public static boolean grinchPresents;
 
     @Property(
-        type = PropertyType.SWITCH, name = "Remove Network Booster Perk Messages",
-        description = "Removes the network booster perk messages from chat.\n§eExample: §6+50 coins (Steve's Network Booster)",
-        category = "Chat", subcategory = "Toggles"
-    )
-    public static boolean boosterPerk;
-
-    @Property(
         type = PropertyType.SWITCH, name = "Remove Earned Coins and Experience Messages",
         description = "Removes the earned coins and experience messages from chat.\n§eExamples:\n§b+25 Bed Wars Experience\n§6+10 coins!",
         category = "Chat", subcategory = "Toggles"

--- a/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
+++ b/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
@@ -234,7 +234,7 @@ public class HytilsConfig extends Vigilant {
 
     @Property(
         type = PropertyType.SWITCH, name = "Remove Stats Messages",
-        description = "Remove the \"view your stats\" messages.\n§eExample: §4Please add me.",
+        description = "Remove the \"view your stats\" messages.\n§eExample: §eClick to view the stats of your §bSkyWars§e game!",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean statsMessages;

--- a/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
+++ b/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
@@ -220,7 +220,7 @@ public class HytilsConfig extends Vigilant {
 
     @Property(
         type = PropertyType.SWITCH, name = "Remove Game Tips Messages",
-        description = "Remove tips about the game you are playing.\n§eExample: §4Please add me.",
+        description = "Remove tips about the game you are playing.\n§eExample: §r§c§lTeaming is not allowed on Solo mode!",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean gameTipMessages;

--- a/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
+++ b/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
@@ -728,6 +728,7 @@ public class HytilsConfig extends Vigilant {
     )
     public static String uhcMiddleWaypointText = "0,0";
 
+    /*
     @Property(
         type = PropertyType.SWITCH, name = "Lower Render Distance in Sumo",
         description = "Lowers render distance to your desired value in sumo duels.",
@@ -742,6 +743,7 @@ public class HytilsConfig extends Vigilant {
         min = 1, max = 5
     )
     public static int sumoRenderDistanceAmount = 2;
+     */
 
     @Property(
         type = PropertyType.SWITCH, name = "Hide Armor",
@@ -994,7 +996,7 @@ public class HytilsConfig extends Vigilant {
 
         addDependency("uhcMiddleWaypointText", "uhcMiddleWaypoint");
 
-        addDependency("sumoRenderDistanceAmount", "sumoRenderDistance");
+        // addDependency("sumoRenderDistanceAmount", "sumoRenderDistance");
 
         addDependency("overlayAmount", "heightOverlay");
 

--- a/src/main/java/cc/woverflow/hytils/handlers/chat/ChatHandler.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/chat/ChatHandler.java
@@ -76,12 +76,14 @@ public class ChatHandler {
         this.registerModule(new QuestBlocker());
         this.registerModule(new GiftBlocker());
         this.registerModule(new GrinchPresentsRemover());
-        this.registerModule(new BoosterRemover());
         this.registerModule(new AutoVictory());
         this.registerModule(new AutoPartyWarpConfirm());
         this.registerModule(new ColoredFriendStatuses());
-        this.registerModule(new GEXPRemover());
-        this.registerModule(new TimePlayedRemover());
+        this.registerModule(new EarnedCoinsAndExpRemover());
+        this.registerModule(new ReplayRecordedRemover());
+        this.registerModule(new TipMessageRemover());
+        this.registerModule(new SendingCommandsRemover());
+        this.registerModule(new OnlineStatusRemover());
 
         this.registerDualModule(new ShoutBlocker());
 

--- a/src/main/java/cc/woverflow/hytils/handlers/chat/ChatHandler.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/chat/ChatHandler.java
@@ -82,8 +82,9 @@ public class ChatHandler {
         this.registerModule(new EarnedCoinsAndExpRemover());
         this.registerModule(new ReplayRecordedRemover());
         this.registerModule(new TipMessageRemover());
-        this.registerModule(new SendingCommandsRemover());
         this.registerModule(new OnlineStatusRemover());
+        this.registerModule(new GameTipsRemover());
+        this.registerModule(new StatsMessageRemover());
 
         this.registerDualModule(new ShoutBlocker());
 

--- a/src/main/java/cc/woverflow/hytils/handlers/chat/modules/blockers/EarnedCoinsAndExpRemover.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/chat/modules/blockers/EarnedCoinsAndExpRemover.java
@@ -1,0 +1,47 @@
+/*
+ * Hytils Reborn - Hypixel focused Quality of Life mod.
+ * Copyright (C) 2022  W-OVERFLOW
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package cc.woverflow.hytils.handlers.chat.modules.blockers;
+
+import cc.woverflow.hytils.config.HytilsConfig;
+import cc.woverflow.hytils.handlers.chat.ChatReceiveModule;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraftforge.client.event.ClientChatReceivedEvent;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.regex.Matcher;
+
+public class EarnedCoinsAndExpRemover implements ChatReceiveModule {
+    @Override
+    public void onMessageReceived(@NotNull ClientChatReceivedEvent event) {
+        Matcher matcher = getLanguage().chatCleanerEarnedCoinsAndExpRegex.matcher(EnumChatFormatting.getTextWithoutFormattingCodes(event.message.getUnformattedText()));
+        if (matcher.matches()) {
+            event.setCanceled(true);
+        }
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return HytilsConfig.earnedCoinsAndExp;
+    }
+
+    @Override
+    public int getPriority() {
+        return -3;
+    }
+}

--- a/src/main/java/cc/woverflow/hytils/handlers/chat/modules/blockers/GameTipsRemover.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/chat/modules/blockers/GameTipsRemover.java
@@ -18,31 +18,30 @@
 
 package cc.woverflow.hytils.handlers.chat.modules.blockers;
 
-import cc.woverflow.hytils.HytilsReborn;
 import cc.woverflow.hytils.config.HytilsConfig;
 import cc.woverflow.hytils.handlers.chat.ChatReceiveModule;
-import cc.woverflow.hytils.handlers.language.LanguageData;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import org.jetbrains.annotations.NotNull;
 
-public class SendingCommandsRemover implements ChatReceiveModule {
+import java.util.regex.Matcher;
+
+public class GameTipsRemover implements ChatReceiveModule {
     @Override
     public void onMessageReceived(@NotNull ClientChatReceivedEvent event) {
-        final LanguageData language = HytilsReborn.INSTANCE.getLanguageHandler().getCurrent();
-
-        if (language.chatCleanerSendingCommands.equals(EnumChatFormatting.getTextWithoutFormattingCodes(event.message.getUnformattedText()))) {
+        Matcher matcher = getLanguage().chatCleanerGameTipsRegex.matcher(EnumChatFormatting.getTextWithoutFormattingCodes(event.message.getUnformattedText()));
+        if (matcher.matches()) {
             event.setCanceled(true);
         }
     }
 
     @Override
     public boolean isEnabled() {
-        return HytilsConfig.tipMessage;
+        return HytilsConfig.gameTipMessages;
     }
 
     @Override
     public int getPriority() {
-        return -3;
+        return -1;
     }
 }

--- a/src/main/java/cc/woverflow/hytils/handlers/chat/modules/blockers/OnlineStatusRemover.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/chat/modules/blockers/OnlineStatusRemover.java
@@ -29,7 +29,7 @@ import java.util.regex.Matcher;
 public class OnlineStatusRemover implements ChatReceiveModule {
     @Override
     public void onMessageReceived(@NotNull ClientChatReceivedEvent event) {
-        Matcher matcher = getLanguage().chatCleanerEarnedCoinsAndExpRegex.matcher(EnumChatFormatting.getTextWithoutFormattingCodes(event.message.getUnformattedText()));
+        Matcher matcher = getLanguage().chatCleanerOnlineStatusRegex.matcher(EnumChatFormatting.getTextWithoutFormattingCodes(event.message.getUnformattedText()));
         if (matcher.matches()) {
             event.setCanceled(true);
         }

--- a/src/main/java/cc/woverflow/hytils/handlers/chat/modules/blockers/OnlineStatusRemover.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/chat/modules/blockers/OnlineStatusRemover.java
@@ -26,11 +26,10 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.regex.Matcher;
 
-public class BoosterRemover implements ChatReceiveModule {
-
+public class OnlineStatusRemover implements ChatReceiveModule {
     @Override
     public void onMessageReceived(@NotNull ClientChatReceivedEvent event) {
-        Matcher matcher = getLanguage().chatCleanerBoosterRemoverRegex.matcher(EnumChatFormatting.getTextWithoutFormattingCodes(event.message.getUnformattedText()));
+        Matcher matcher = getLanguage().chatCleanerEarnedCoinsAndExpRegex.matcher(EnumChatFormatting.getTextWithoutFormattingCodes(event.message.getUnformattedText()));
         if (matcher.matches()) {
             event.setCanceled(true);
         }
@@ -38,12 +37,11 @@ public class BoosterRemover implements ChatReceiveModule {
 
     @Override
     public boolean isEnabled() {
-        return HytilsConfig.boosterRemover;
+        return HytilsConfig.onlineStatus;
     }
 
     @Override
     public int getPriority() {
         return -1;
     }
-
 }

--- a/src/main/java/cc/woverflow/hytils/handlers/chat/modules/blockers/ReplayRecordedRemover.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/chat/modules/blockers/ReplayRecordedRemover.java
@@ -20,17 +20,13 @@ package cc.woverflow.hytils.handlers.chat.modules.blockers;
 
 import cc.woverflow.hytils.config.HytilsConfig;
 import cc.woverflow.hytils.handlers.chat.ChatReceiveModule;
-import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.regex.Matcher;
 
 public class ReplayRecordedRemover implements ChatReceiveModule {
     @Override
     public void onMessageReceived(@NotNull ClientChatReceivedEvent event) {
-        Matcher matcher = getLanguage().chatCleanerReplayRecordedRegex.matcher(EnumChatFormatting.getTextWithoutFormattingCodes(event.message.getUnformattedText()));
-        if (matcher.matches()) {
+        if (event.message.getFormattedText().equals(getLanguage().chatCleanerReplyRecorded)) {
             event.setCanceled(true);
         }
     }

--- a/src/main/java/cc/woverflow/hytils/handlers/chat/modules/blockers/ReplayRecordedRemover.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/chat/modules/blockers/ReplayRecordedRemover.java
@@ -26,10 +26,10 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.regex.Matcher;
 
-public class TimePlayedRemover implements ChatReceiveModule {
+public class ReplayRecordedRemover implements ChatReceiveModule {
     @Override
     public void onMessageReceived(@NotNull ClientChatReceivedEvent event) {
-        Matcher matcher = getLanguage().chatTimePlayedRemoverRegex.matcher(EnumChatFormatting.getTextWithoutFormattingCodes(event.message.getUnformattedText()));
+        Matcher matcher = getLanguage().chatCleanerReplayRecordedRegex.matcher(EnumChatFormatting.getTextWithoutFormattingCodes(event.message.getUnformattedText()));
         if (matcher.matches()) {
             event.setCanceled(true);
         }
@@ -37,11 +37,11 @@ public class TimePlayedRemover implements ChatReceiveModule {
 
     @Override
     public boolean isEnabled() {
-        return HytilsConfig.timePlayedRemover;
+        return HytilsConfig.replayMessage;
     }
 
     @Override
     public int getPriority() {
-        return -3;
+        return -1;
     }
 }

--- a/src/main/java/cc/woverflow/hytils/handlers/chat/modules/blockers/SendingCommandsRemover.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/chat/modules/blockers/SendingCommandsRemover.java
@@ -18,26 +18,27 @@
 
 package cc.woverflow.hytils.handlers.chat.modules.blockers;
 
+import cc.woverflow.hytils.HytilsReborn;
 import cc.woverflow.hytils.config.HytilsConfig;
 import cc.woverflow.hytils.handlers.chat.ChatReceiveModule;
+import cc.woverflow.hytils.handlers.language.LanguageData;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.regex.Matcher;
-
-public class GEXPRemover implements ChatReceiveModule {
+public class SendingCommandsRemover implements ChatReceiveModule {
     @Override
     public void onMessageReceived(@NotNull ClientChatReceivedEvent event) {
-        Matcher matcher = getLanguage().chatGEXPRemoverRegex.matcher(EnumChatFormatting.getTextWithoutFormattingCodes(event.message.getUnformattedText()));
-        if (matcher.matches()) {
+        final LanguageData language = HytilsReborn.INSTANCE.getLanguageHandler().getCurrent();
+
+        if (language.chatCleanerSendingCommands.equals(EnumChatFormatting.getTextWithoutFormattingCodes(event.message.getUnformattedText()))) {
             event.setCanceled(true);
         }
     }
 
     @Override
     public boolean isEnabled() {
-        return HytilsConfig.gexpRemover;
+        return HytilsConfig.tipMessage;
     }
 
     @Override

--- a/src/main/java/cc/woverflow/hytils/handlers/chat/modules/blockers/ShoutBlocker.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/chat/modules/blockers/ShoutBlocker.java
@@ -35,7 +35,6 @@ import java.text.DecimalFormat;
  * If there are more modes supporting /shout, feel free to add support for them.
  */
 public class ShoutBlocker implements ChatSendModule, ChatReceiveModule {
-
     @Override
     public int getPriority() {
         return -3;

--- a/src/main/java/cc/woverflow/hytils/handlers/chat/modules/blockers/StatsMessageRemover.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/chat/modules/blockers/StatsMessageRemover.java
@@ -26,10 +26,10 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.regex.Matcher;
 
-public class TipMessageRemover implements ChatReceiveModule {
+public class StatsMessageRemover implements ChatReceiveModule {
     @Override
     public void onMessageReceived(@NotNull ClientChatReceivedEvent event) {
-        Matcher matcher = getLanguage().chatCleanerTipRegex.matcher(EnumChatFormatting.getTextWithoutFormattingCodes(event.message.getUnformattedText()));
+        Matcher matcher = getLanguage().chatCleanerStatsRegex.matcher(EnumChatFormatting.getTextWithoutFormattingCodes(event.message.getUnformattedText()));
         if (matcher.matches()) {
             event.setCanceled(true);
         }
@@ -37,7 +37,7 @@ public class TipMessageRemover implements ChatReceiveModule {
 
     @Override
     public boolean isEnabled() {
-        return HytilsConfig.tipMessage;
+        return HytilsConfig.statsMessages;
     }
 
     @Override

--- a/src/main/java/cc/woverflow/hytils/handlers/chat/modules/blockers/TipMessageRemover.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/chat/modules/blockers/TipMessageRemover.java
@@ -1,0 +1,47 @@
+/*
+ * Hytils Reborn - Hypixel focused Quality of Life mod.
+ * Copyright (C) 2022  W-OVERFLOW
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package cc.woverflow.hytils.handlers.chat.modules.blockers;
+
+import cc.woverflow.hytils.config.HytilsConfig;
+import cc.woverflow.hytils.handlers.chat.ChatReceiveModule;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraftforge.client.event.ClientChatReceivedEvent;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.regex.Matcher;
+
+public class TipMessageRemover implements ChatReceiveModule {
+    @Override
+    public void onMessageReceived(@NotNull ClientChatReceivedEvent event) {
+        Matcher matcher = getLanguage().chatCleanerEarnedCoinsAndExpRegex.matcher(EnumChatFormatting.getTextWithoutFormattingCodes(event.message.getUnformattedText()));
+        if (matcher.matches()) {
+            event.setCanceled(true);
+        }
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return HytilsConfig.tipMessage;
+    }
+
+    @Override
+    public int getPriority() {
+        return -1;
+    }
+}

--- a/src/main/java/cc/woverflow/hytils/handlers/game/GameStartingTitles.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/game/GameStartingTitles.java
@@ -44,6 +44,7 @@ public class GameStartingTitles {
             case "SkyWars":
             case "INSANE MODE":
             case "Waiting for more players...":
+            case "ASSASSINS":
                 event.setCanceled(true);
                 break;
         }

--- a/src/main/java/cc/woverflow/hytils/handlers/game/duels/SumoRenderDistance.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/game/duels/SumoRenderDistance.java
@@ -28,6 +28,7 @@ import net.minecraftforge.client.event.RenderWorldLastEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 public class SumoRenderDistance {
+    /*
     final GameSettings gs = Minecraft.getMinecraft().gameSettings;
     final int oldRd = gs.renderDistanceChunks;
 
@@ -41,4 +42,5 @@ public class SumoRenderDistance {
             gs.renderDistanceChunks = oldRd;
         }
     }
+     */
 }

--- a/src/main/java/cc/woverflow/hytils/handlers/game/duels/SumoRenderDistance.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/game/duels/SumoRenderDistance.java
@@ -1,0 +1,44 @@
+/*
+ * Hytils Reborn - Hypixel focused Quality of Life mod.
+ * Copyright (C) 2022  W-OVERFLOW
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package cc.woverflow.hytils.handlers.game.duels;
+
+import cc.woverflow.hytils.HytilsReborn;
+import cc.woverflow.hytils.config.HytilsConfig;
+import cc.woverflow.hytils.util.locraw.LocrawInformation;
+import gg.essential.api.EssentialAPI;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.settings.GameSettings;
+import net.minecraftforge.client.event.RenderWorldLastEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+public class SumoRenderDistance {
+    final GameSettings gs = Minecraft.getMinecraft().gameSettings;
+    final int oldRd = gs.renderDistanceChunks;
+
+    @SubscribeEvent
+    public void onRenderWorld(RenderWorldLastEvent event) {
+        LocrawInformation locraw = HytilsReborn.INSTANCE.getLocrawUtil().getLocrawInformation();
+        if (HytilsConfig.sumoRenderDistance && EssentialAPI.getMinecraftUtil().isHypixel() && (locraw != null && locraw.getGameMode().contains("SUMO"))) {
+            gs.renderDistanceChunks = HytilsConfig.sumoRenderDistanceAmount;
+        }
+        else {
+            gs.renderDistanceChunks = oldRd;
+        }
+    }
+}

--- a/src/main/java/cc/woverflow/hytils/handlers/game/miniwalls/MiddleBeaconMiniWalls.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/game/miniwalls/MiddleBeaconMiniWalls.java
@@ -19,54 +19,42 @@
 package cc.woverflow.hytils.handlers.game.miniwalls;
 
 
+import cc.woverflow.hytils.HytilsReborn;
 import cc.woverflow.hytils.config.HytilsConfig;
 import cc.woverflow.hytils.events.TitleEvent;
-import cc.woverflow.onecore.utils.RenderUtils;
+import cc.woverflow.hytils.util.WaypointUtil;
+import cc.woverflow.hytils.util.locraw.LocrawInformation;
 import gg.essential.api.EssentialAPI;
 import net.minecraft.util.BlockPos;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
-import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
-public class MiddleWaypoint {
-
-
+public class MiddleBeaconMiniWalls {
     private boolean miniWitherDead;
-    private String location;
-    private Float x = 0f;
-    private Float y = 2f;
-    private Float z = 0f;
+    private final BlockPos block = new BlockPos(0, 0, 0);
 
     @SubscribeEvent
     public void onWorldLoad(WorldEvent.Load event) {
-        if (this.miniWitherDead) {
-            this.miniWitherDead = false;
-        }
+        if (this.miniWitherDead) this.miniWitherDead = false;
     }
 
     @SubscribeEvent
     public void onTitle(TitleEvent event) {
         final String unformattedTitle = EnumChatFormatting.getTextWithoutFormattingCodes(event.getTitle());
 
-        if (unformattedTitle != null && (unformattedTitle.equals("Your Mini Wither died!") ||
-            unformattedTitle.equals("DEATHMATCH")) &&
-            HytilsConfig.miniWallsMiddleWaypoint) {
-            miniWitherDead = true;
-        }
+        if (unformattedTitle != null && (unformattedTitle.equals("Your Mini Wither died!") || unformattedTitle.equals("DEATHMATCH")) && HytilsConfig.miniWallsMiddleBeacon) miniWitherDead = true;
     }
 
     public boolean shouldMakeBeacon() {
-        return this.miniWitherDead && HytilsConfig.miniWallsMiddleWaypoint;
+        LocrawInformation locraw = HytilsReborn.INSTANCE.getLocrawUtil().getLocrawInformation();
+        return EssentialAPI.getMinecraftUtil().isHypixel() && (locraw != null && locraw.getGameMode().equalsIgnoreCase("mini_walls") && this.miniWitherDead && HytilsConfig.miniWallsMiddleBeacon);
     }
 
     @SubscribeEvent
-    public void onRenderLast(RenderWorldLastEvent event) {
-        if (!HytilsConfig.miniWallsMiddleWaypoint) return;
-        int rgb = 0xa839ce;
-        if (miniWitherDead) return;{
-
-        }
+    public void onRenderWorldLast(RenderWorldLastEvent event) {
+        if (!shouldMakeBeacon()) return;
+        WaypointUtil.renderBeaconBeam(block, HytilsConfig.miniWallsMiddleBeaconColor.getRGB(), 1.0f, event.partialTicks);
     }
 }

--- a/src/main/java/cc/woverflow/hytils/handlers/game/uhc/MiddleWaypointUHC.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/game/uhc/MiddleWaypointUHC.java
@@ -1,0 +1,41 @@
+/*
+ * Hytils Reborn - Hypixel focused Quality of Life mod.
+ * Copyright (C) 2022  W-OVERFLOW
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package cc.woverflow.hytils.handlers.game.uhc;
+
+import cc.woverflow.hytils.HytilsReborn;
+import cc.woverflow.hytils.config.HytilsConfig;
+import cc.woverflow.hytils.handlers.game.GameType;
+import cc.woverflow.hytils.util.WaypointUtil;
+import cc.woverflow.hytils.util.locraw.LocrawInformation;
+import gg.essential.api.EssentialAPI;
+import net.minecraft.util.BlockPos;
+import net.minecraftforge.client.event.RenderWorldLastEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+public class MiddleWaypointUHC {
+    private final BlockPos block = new BlockPos(0,70,0);
+
+    @SubscribeEvent
+    public void onRenderWorldLast(RenderWorldLastEvent event) {
+        LocrawInformation locraw = HytilsReborn.INSTANCE.getLocrawUtil().getLocrawInformation();
+        if (EssentialAPI.getMinecraftUtil().isHypixel() && HytilsConfig.uhcMiddleWaypoint && (locraw != null && (locraw.getGameType() == GameType.UHC_CHAMPIONS || locraw.getGameType() == GameType.SPEED_UHC))) {
+            WaypointUtil.renderWayPoint(HytilsConfig.uhcMiddleWaypointText, block, event.partialTicks);
+        }
+    }
+}

--- a/src/main/java/cc/woverflow/hytils/handlers/game/uhc/MiddleWaypointUHC.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/game/uhc/MiddleWaypointUHC.java
@@ -29,6 +29,7 @@ import net.minecraftforge.client.event.RenderWorldLastEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 public class MiddleWaypointUHC {
+    // y 70 is a completely arbitrary height, being slightly above sea level. feel free to change as one may see fit
     private final BlockPos block = new BlockPos(0,70,0);
 
     @SubscribeEvent

--- a/src/main/java/cc/woverflow/hytils/handlers/language/LanguageData.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/language/LanguageData.java
@@ -30,7 +30,6 @@ import java.util.regex.Pattern;
  */
 @SuppressWarnings({"FieldCanBeLocal", "FieldMayBeFinal", "DuplicatedCode"})
 public class LanguageData {
-
     private boolean hasInitialized = false;
 
     /**
@@ -51,9 +50,11 @@ public class LanguageData {
     public String chatCleanerHypeLimit = "  \u27A4 You have reached your Hype limit!";
     private String chatGiftBlocker = "They have gifted \\d+ ranks so far!";
     private String chatCleanerGrinchPresents = "(?:You found a gift! .\\d{1,3} total.|^\\W{0,3}\\w{0,}\\S{0,3}\\s{0,1}\\w{1,16} has reached \\d{2,3} gifts!)";
-    private String chatCleanerBoosterRemover = "^\\W\\d{1,} coins! .\\w{1,16}.s Network Booster. .*";
-    private String chatGEXPRemover = "You earned \\d+ GEXP from playing \\.+!";
-    private String chatTimePlayerRemover = "^(?:\\W\\d+ .* Experience \\(Time Played\\)|\\W\\d+ coins! \\(Time Played\\)).*"; //.* at the end in case of any modifiers such as boosters
+    private String chatCleanerEarnedCoinsAndExp = "^(?:\\W\\d+ .* Experience.*|\\W\\d+ coins!.*|You earned \\d+ GEXP from playing\\.+!|.+ just earned .+ as a Guild Level Reward!)"; //.* at the end for modifiers
+    private String chatCleanerReplyRecorded = "This game has been recorded. Click here to watch the Replay!";
+    private String chatCleanerTip = "(?:You tipped \\d+ (?:player|players) in \\d+ (?:game|different games)!|You already tipped everyone that has boosters active, so there isn't anybody to be tipped right now!)";
+    private String chatCleanerOnlineStatus = "REMINDER: Your Online Status is currently set to (?:Appear Offline|Busy|Away)";
+    public String chatCleanerSendingCommands = "You are sending commands too fast! Please slow down.";
 
     private String connectedServerConnectMessage = "^(You are currently connected to server \\S+)|(Sending you to \\S+.{3}!)|(Sending to server \\S+.{3})|(Warping you to your Skyblock island...)|(Warping...)|(Sending a visit request...)|(Finding player...)$";
 
@@ -71,7 +72,6 @@ public class LanguageData {
     private String chatRestylerFriendPattern = "^((?:\\u00a7r)?\\u00a7\\w)(Friend >)";
     private String chatRestylerOfficerPattern = "^((?:\\u00a7r)?\\u00a7\\w)(Officer >)";
     private String chatRestylerStatusPattern = "^(?<type>(?:§aFriend|§a§aF|§2Guild|§2§2G)) > (§r|§r§r){1,2}(?<player>§[\\da-f]\\w{1,16}) §r§e(?<status>(?:joined|left))\\.§r$";
-
 
     private String autoChatSwapperPartyStatus = "^(?:You have been kicked from the party by (?:\\[.+] )?\\w{1,16}|(?:\\[.+] )?\\w{1,16} has disbanded the party!|You left the party(?:\\[.+] )?\\w{0,16}|(?:\\[.+] )?\\w{1,100}The party was disbanded(?:\\[.+] )?\\w{1,100}.)$";
     private String autoChatSwapperPartyStatus2 = "^(?:You have joined (?:\\[.+] )?(?:.*)|Party Members(?:\\[.+] )?\\w{1,100}|(?:\\[.+] )?\\w{1,100} joined the(?:.*) party(?:.*))$";
@@ -108,9 +108,10 @@ public class LanguageData {
     public Pattern chatCleanerMvpEmotesRegex;
     public Pattern chatGiftBlockerRegex;
     public Pattern chatCleanerGrinchPresentsRegex;
-    public Pattern chatCleanerBoosterRemoverRegex;
-    public Pattern chatGEXPRemoverRegex;
-    public Pattern chatTimePlayedRemoverRegex;
+    public Pattern chatCleanerEarnedCoinsAndExpRegex;
+    public Pattern chatCleanerReplayRecordedRegex;
+    public Pattern chatCleanerTipRegex;
+    public Pattern chatCleanerOnlineStatusRegex;
 
     public Pattern connectedServerConnectMessageRegex;
 
@@ -155,9 +156,10 @@ public class LanguageData {
             chatCleanerMvpEmotesRegex = Pattern.compile(chatCleanerMvpEmotes);
             chatGiftBlockerRegex = Pattern.compile(chatGiftBlocker);
             chatCleanerGrinchPresentsRegex = Pattern.compile(chatCleanerGrinchPresents);
-            chatCleanerBoosterRemoverRegex = Pattern.compile(chatCleanerBoosterRemover);
-            chatGEXPRemoverRegex = Pattern.compile(chatGEXPRemover);
-            chatTimePlayedRemoverRegex = Pattern.compile(chatTimePlayerRemover);
+            chatCleanerEarnedCoinsAndExpRegex = Pattern.compile(chatCleanerEarnedCoinsAndExp);
+            chatCleanerReplayRecordedRegex = Pattern.compile(chatCleanerReplyRecorded);
+            chatCleanerTipRegex = Pattern.compile(chatCleanerTip);
+            chatCleanerOnlineStatusRegex = Pattern.compile(chatCleanerOnlineStatus);
 
             connectedServerConnectMessageRegex = Pattern.compile(connectedServerConnectMessage);
 

--- a/src/main/java/cc/woverflow/hytils/handlers/language/LanguageData.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/language/LanguageData.java
@@ -54,7 +54,8 @@ public class LanguageData {
     private String chatCleanerReplyRecorded = "This game has been recorded. Click here to watch the Replay!";
     private String chatCleanerTip = "(?:You tipped \\d+ (?:player|players) in \\d+ (?:game|different games)!|You already tipped everyone that has boosters active, so there isn't anybody to be tipped right now!)";
     private String chatCleanerOnlineStatus = "REMINDER: Your Online Status is currently set to (?:Appear Offline|Busy|Away)";
-    public String chatCleanerSendingCommands = "You are sending commands too fast! Please slow down.";
+    private String chatCleanerGameTips = "^(?:If you get disconnected use /rejoin to join back in the game.|You may use /mmreport <skin name> to chat report in this mode!|Teaming with the *.+ is not allowed!|Teaming is not allowed *.+|Cross Teaming / Teaming with other teams is not allowed!|Cross-teaming is not allowed! Report cross-teamers using /report.|Cages opened! FIGHT!)";
+    private String chatCleanerStats = "Click to view the stats of your \\S+ game!";
 
     private String connectedServerConnectMessage = "^(You are currently connected to server \\S+)|(Sending you to \\S+.{3}!)|(Sending to server \\S+.{3})|(Warping you to your Skyblock island...)|(Warping...)|(Sending a visit request...)|(Finding player...)$";
 
@@ -112,6 +113,8 @@ public class LanguageData {
     public Pattern chatCleanerReplayRecordedRegex;
     public Pattern chatCleanerTipRegex;
     public Pattern chatCleanerOnlineStatusRegex;
+    public Pattern chatCleanerGameTipsRegex;
+    public Pattern chatCleanerStatsRegex;
 
     public Pattern connectedServerConnectMessageRegex;
 
@@ -160,6 +163,8 @@ public class LanguageData {
             chatCleanerReplayRecordedRegex = Pattern.compile(chatCleanerReplyRecorded);
             chatCleanerTipRegex = Pattern.compile(chatCleanerTip);
             chatCleanerOnlineStatusRegex = Pattern.compile(chatCleanerOnlineStatus);
+            chatCleanerGameTipsRegex = Pattern.compile(chatCleanerGameTips);
+            chatCleanerStatsRegex = Pattern.compile(chatCleanerStats);
 
             connectedServerConnectMessageRegex = Pattern.compile(connectedServerConnectMessage);
 

--- a/src/main/java/cc/woverflow/hytils/handlers/language/LanguageData.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/language/LanguageData.java
@@ -51,7 +51,7 @@ public class LanguageData {
     private String chatGiftBlocker = "They have gifted \\d+ ranks so far!";
     private String chatCleanerGrinchPresents = "(?:You found a gift! .\\d{1,3} total.|^\\W{0,3}\\w{0,}\\S{0,3}\\s{0,1}\\w{1,16} has reached \\d{2,3} gifts!)";
     private String chatCleanerEarnedCoinsAndExp = "^(?:\\W\\d+ .* Experience.*|\\W\\d+ coins!.*|You earned \\d+ GEXP from playing\\.+!|.+ just earned .+ as a Guild Level Reward!)"; //.* at the end for modifiers
-    private String chatCleanerReplyRecorded = "This game has been recorded. Click here to watch the Replay!";
+    public String chatCleanerReplyRecorded = "This game has been recorded. Click here to watch the Replay!";
     private String chatCleanerTip = "(?:You tipped \\d+ (?:player|players) in \\d+ (?:game|different games)!|You already tipped everyone that has boosters active, so there isn't anybody to be tipped right now!)";
     private String chatCleanerOnlineStatus = "REMINDER: Your Online Status is currently set to (?:Appear Offline|Busy|Away)";
     private String chatCleanerGameTips = "^(?:If you get disconnected use /rejoin to join back in the game.|You may use /mmreport <skin name> to chat report in this mode!|Teaming with the *.+ is not allowed!|Teaming is not allowed *.+|Cross Teaming / Teaming with other teams is not allowed!|Cross-teaming is not allowed! Report cross-teamers using /report.|Cages opened! FIGHT!)";
@@ -110,7 +110,6 @@ public class LanguageData {
     public Pattern chatGiftBlockerRegex;
     public Pattern chatCleanerGrinchPresentsRegex;
     public Pattern chatCleanerEarnedCoinsAndExpRegex;
-    public Pattern chatCleanerReplayRecordedRegex;
     public Pattern chatCleanerTipRegex;
     public Pattern chatCleanerOnlineStatusRegex;
     public Pattern chatCleanerGameTipsRegex;
@@ -160,7 +159,6 @@ public class LanguageData {
             chatGiftBlockerRegex = Pattern.compile(chatGiftBlocker);
             chatCleanerGrinchPresentsRegex = Pattern.compile(chatCleanerGrinchPresents);
             chatCleanerEarnedCoinsAndExpRegex = Pattern.compile(chatCleanerEarnedCoinsAndExp);
-            chatCleanerReplayRecordedRegex = Pattern.compile(chatCleanerReplyRecorded);
             chatCleanerTipRegex = Pattern.compile(chatCleanerTip);
             chatCleanerOnlineStatusRegex = Pattern.compile(chatCleanerOnlineStatus);
             chatCleanerGameTipsRegex = Pattern.compile(chatCleanerGameTips);

--- a/src/main/java/cc/woverflow/hytils/util/WaypointUtil.java
+++ b/src/main/java/cc/woverflow/hytils/util/WaypointUtil.java
@@ -1,0 +1,338 @@
+/*
+ * Hytils Reborn - Hypixel focused Quality of Life mod.
+ * Copyright (C) 2022  W-OVERFLOW
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package cc.woverflow.hytils.util;
+
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.WorldRenderer;
+import net.minecraft.client.renderer.entity.RenderManager;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.*;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.util.vector.Vector3f;
+
+import java.awt.*;
+
+/**
+ * Taken and adapted from NotEnoughUpdates under Creative Commons Attribution-NonCommercial 3.0
+ * https://github.com/Moulberry/NotEnoughUpdates/blob/master/LICENSE
+ * @author Moulberry
+ */
+public class WaypointUtil {
+    public static final Minecraft mc = Minecraft.getMinecraft();
+
+    private static final ResourceLocation beaconBeam = new ResourceLocation("textures/entity/beacon_beam.png");
+
+    private static void renderBeaconBeam(
+        double x, double y, double z, int rgb, float alphaMult,
+        float partialTicks, Boolean disableDepth
+    ) {
+        int height = 300;
+        int bottomOffset = 0;
+        int topOffset = bottomOffset + height;
+
+        Tessellator tessellator = Tessellator.getInstance();
+        WorldRenderer worldrenderer = tessellator.getWorldRenderer();
+
+        if (disableDepth) {
+            GlStateManager.disableDepth();
+        }
+
+        Minecraft.getMinecraft().getTextureManager().bindTexture(beaconBeam);
+        GL11.glTexParameterf(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_S, GL11.GL_REPEAT);
+        GL11.glTexParameterf(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_T, GL11.GL_REPEAT);
+        GlStateManager.disableLighting();
+        GlStateManager.enableCull();
+        GlStateManager.enableTexture2D();
+        GlStateManager.tryBlendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE, GL11.GL_ONE, GL11.GL_ZERO);
+        GlStateManager.enableBlend();
+        GlStateManager.tryBlendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, GL11.GL_ONE, GL11.GL_ZERO);
+
+        double time = Minecraft.getMinecraft().theWorld.getTotalWorldTime() + (double) partialTicks;
+        double d1 = MathHelper.func_181162_h(-time * 0.2D - (double) MathHelper.floor_double(-time * 0.1D));
+
+        float r = ((rgb >> 16) & 0xFF) / 255f;
+        float g = ((rgb >> 8) & 0xFF) / 255f;
+        float b = (rgb & 0xFF) / 255f;
+        double d2 = time * 0.025D * -1.5D;
+        double d4 = 0.5D + Math.cos(d2 + 2.356194490192345D) * 0.2D;
+        double d5 = 0.5D + Math.sin(d2 + 2.356194490192345D) * 0.2D;
+        double d6 = 0.5D + Math.cos(d2 + (Math.PI / 4D)) * 0.2D;
+        double d7 = 0.5D + Math.sin(d2 + (Math.PI / 4D)) * 0.2D;
+        double d8 = 0.5D + Math.cos(d2 + 3.9269908169872414D) * 0.2D;
+        double d9 = 0.5D + Math.sin(d2 + 3.9269908169872414D) * 0.2D;
+        double d10 = 0.5D + Math.cos(d2 + 5.497787143782138D) * 0.2D;
+        double d11 = 0.5D + Math.sin(d2 + 5.497787143782138D) * 0.2D;
+        double d14 = -1.0D + d1;
+        double d15 = (double) (height) * 2.5D + d14;
+        worldrenderer.begin(7, DefaultVertexFormats.POSITION_TEX_COLOR);
+        worldrenderer.pos(x + d4, y + topOffset, z + d5).tex(1.0D, d15).color(r, g, b, 1.0F * alphaMult).endVertex();
+        worldrenderer.pos(x + d4, y + bottomOffset, z + d5).tex(1.0D, d14).color(r, g, b, 1.0F).endVertex();
+        worldrenderer.pos(x + d6, y + bottomOffset, z + d7).tex(0.0D, d14).color(r, g, b, 1.0F).endVertex();
+        worldrenderer.pos(x + d6, y + topOffset, z + d7).tex(0.0D, d15).color(r, g, b, 1.0F * alphaMult).endVertex();
+        worldrenderer.pos(x + d10, y + topOffset, z + d11).tex(1.0D, d15).color(r, g, b, 1.0F * alphaMult).endVertex();
+        worldrenderer.pos(x + d10, y + bottomOffset, z + d11).tex(1.0D, d14).color(r, g, b, 1.0F).endVertex();
+        worldrenderer.pos(x + d8, y + bottomOffset, z + d9).tex(0.0D, d14).color(r, g, b, 1.0F).endVertex();
+        worldrenderer.pos(x + d8, y + topOffset, z + d9).tex(0.0D, d15).color(r, g, b, 1.0F * alphaMult).endVertex();
+        worldrenderer.pos(x + d6, y + topOffset, z + d7).tex(1.0D, d15).color(r, g, b, 1.0F * alphaMult).endVertex();
+        worldrenderer.pos(x + d6, y + bottomOffset, z + d7).tex(1.0D, d14).color(r, g, b, 1.0F).endVertex();
+        worldrenderer.pos(x + d10, y + bottomOffset, z + d11).tex(0.0D, d14).color(r, g, b, 1.0F).endVertex();
+        worldrenderer.pos(x + d10, y + topOffset, z + d11).tex(0.0D, d15).color(r, g, b, 1.0F * alphaMult).endVertex();
+        worldrenderer.pos(x + d8, y + topOffset, z + d9).tex(1.0D, d15).color(r, g, b, 1.0F * alphaMult).endVertex();
+        worldrenderer.pos(x + d8, y + bottomOffset, z + d9).tex(1.0D, d14).color(r, g, b, 1.0F).endVertex();
+        worldrenderer.pos(x + d4, y + bottomOffset, z + d5).tex(0.0D, d14).color(r, g, b, 1.0F).endVertex();
+        worldrenderer.pos(x + d4, y + topOffset, z + d5).tex(0.0D, d15).color(r, g, b, 1.0F * alphaMult).endVertex();
+        tessellator.draw();
+
+        GlStateManager.disableCull();
+        double d12 = -1.0D + d1;
+        double d13 = height + d12;
+
+        worldrenderer.begin(7, DefaultVertexFormats.POSITION_TEX_COLOR);
+        worldrenderer.pos(x + 0.2D, y + topOffset, z + 0.2D).tex(1.0D, d13).color(r, g, b, 0.25F * alphaMult).endVertex();
+        worldrenderer.pos(x + 0.2D, y + bottomOffset, z + 0.2D).tex(1.0D, d12).color(r, g, b, 0.25F).endVertex();
+        worldrenderer.pos(x + 0.8D, y + bottomOffset, z + 0.2D).tex(0.0D, d12).color(r, g, b, 0.25F).endVertex();
+        worldrenderer.pos(x + 0.8D, y + topOffset, z + 0.2D).tex(0.0D, d13).color(r, g, b, 0.25F * alphaMult).endVertex();
+        worldrenderer.pos(x + 0.8D, y + topOffset, z + 0.8D).tex(1.0D, d13).color(r, g, b, 0.25F * alphaMult).endVertex();
+        worldrenderer.pos(x + 0.8D, y + bottomOffset, z + 0.8D).tex(1.0D, d12).color(r, g, b, 0.25F).endVertex();
+        worldrenderer.pos(x + 0.2D, y + bottomOffset, z + 0.8D).tex(0.0D, d12).color(r, g, b, 0.25F).endVertex();
+        worldrenderer.pos(x + 0.2D, y + topOffset, z + 0.8D).tex(0.0D, d13).color(r, g, b, 0.25F * alphaMult).endVertex();
+        worldrenderer.pos(x + 0.8D, y + topOffset, z + 0.2D).tex(1.0D, d13).color(r, g, b, 0.25F * alphaMult).endVertex();
+        worldrenderer.pos(x + 0.8D, y + bottomOffset, z + 0.2D).tex(1.0D, d12).color(r, g, b, 0.25F).endVertex();
+        worldrenderer.pos(x + 0.8D, y + bottomOffset, z + 0.8D).tex(0.0D, d12).color(r, g, b, 0.25F).endVertex();
+        worldrenderer.pos(x + 0.8D, y + topOffset, z + 0.8D).tex(0.0D, d13).color(r, g, b, 0.25F * alphaMult).endVertex();
+        worldrenderer.pos(x + 0.2D, y + topOffset, z + 0.8D).tex(1.0D, d13).color(r, g, b, 0.25F * alphaMult).endVertex();
+        worldrenderer.pos(x + 0.2D, y + bottomOffset, z + 0.8D).tex(1.0D, d12).color(r, g, b, 0.25F).endVertex();
+        worldrenderer.pos(x + 0.2D, y + bottomOffset, z + 0.2D).tex(0.0D, d12).color(r, g, b, 0.25F).endVertex();
+        worldrenderer.pos(x + 0.2D, y + topOffset, z + 0.2D).tex(0.0D, d13).color(r, g, b, 0.25F * alphaMult).endVertex();
+        tessellator.draw();
+
+        GlStateManager.disableLighting();
+        GlStateManager.enableTexture2D();
+        if (disableDepth) {
+            GlStateManager.enableDepth();
+        }
+    }
+
+    private static void renderBoundingBox(double x, double y, double z, int rgb, float alphaMult, float partialTicks) {
+        AxisAlignedBB bb = new AxisAlignedBB(x, y, z, x + 1, y + 1, z + 1);
+
+        GlStateManager.disableDepth();
+        GlStateManager.disableCull();
+        GlStateManager.disableTexture2D();
+        drawFilledBoundingBox(bb, 1f, new Color(rgb));
+        GlStateManager.enableTexture2D();
+        GlStateManager.enableCull();
+        GlStateManager.enableDepth();
+    }
+
+    public static void drawFilledBoundingBox(AxisAlignedBB p_181561_0_, float alpha, Color color) {
+
+        GlStateManager.enableBlend();
+        GlStateManager.tryBlendFuncSeparate(770, 771, 1, 0);
+        GlStateManager.disableTexture2D();
+
+        Tessellator tessellator = Tessellator.getInstance();
+        WorldRenderer worldrenderer = tessellator.getWorldRenderer();
+
+        GlStateManager.color(color.getRed() / 255f, color.getGreen() / 255f, color.getBlue() / 255f, color.getAlpha() / 255f * alpha);
+
+        //vertical
+        worldrenderer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION);
+        worldrenderer.pos(p_181561_0_.minX, p_181561_0_.minY, p_181561_0_.minZ).endVertex();
+        worldrenderer.pos(p_181561_0_.maxX, p_181561_0_.minY, p_181561_0_.minZ).endVertex();
+        worldrenderer.pos(p_181561_0_.maxX, p_181561_0_.minY, p_181561_0_.maxZ).endVertex();
+        worldrenderer.pos(p_181561_0_.minX, p_181561_0_.minY, p_181561_0_.maxZ).endVertex();
+        tessellator.draw();
+        worldrenderer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION);
+        worldrenderer.pos(p_181561_0_.minX, p_181561_0_.maxY, p_181561_0_.maxZ).endVertex();
+        worldrenderer.pos(p_181561_0_.maxX, p_181561_0_.maxY, p_181561_0_.maxZ).endVertex();
+        worldrenderer.pos(p_181561_0_.maxX, p_181561_0_.maxY, p_181561_0_.minZ).endVertex();
+        worldrenderer.pos(p_181561_0_.minX, p_181561_0_.maxY, p_181561_0_.minZ).endVertex();
+        tessellator.draw();
+
+        GlStateManager.color(
+            color.getRed() / 255f * 0.8f,
+            color.getGreen() / 255f * 0.8f,
+            color.getBlue() / 255f * 0.8f,
+            color.getAlpha() / 255f * alpha
+        );
+
+        //x
+        worldrenderer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION);
+        worldrenderer.pos(p_181561_0_.minX, p_181561_0_.minY, p_181561_0_.maxZ).endVertex();
+        worldrenderer.pos(p_181561_0_.minX, p_181561_0_.maxY, p_181561_0_.maxZ).endVertex();
+        worldrenderer.pos(p_181561_0_.minX, p_181561_0_.maxY, p_181561_0_.minZ).endVertex();
+        worldrenderer.pos(p_181561_0_.minX, p_181561_0_.minY, p_181561_0_.minZ).endVertex();
+        tessellator.draw();
+        worldrenderer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION);
+        worldrenderer.pos(p_181561_0_.maxX, p_181561_0_.minY, p_181561_0_.minZ).endVertex();
+        worldrenderer.pos(p_181561_0_.maxX, p_181561_0_.maxY, p_181561_0_.minZ).endVertex();
+        worldrenderer.pos(p_181561_0_.maxX, p_181561_0_.maxY, p_181561_0_.maxZ).endVertex();
+        worldrenderer.pos(p_181561_0_.maxX, p_181561_0_.minY, p_181561_0_.maxZ).endVertex();
+        tessellator.draw();
+
+        GlStateManager.color(
+            color.getRed() / 255f * 0.9f,
+            color.getGreen() / 255f * 0.9f,
+            color.getBlue() / 255f * 0.9f,
+            color.getAlpha() / 255f * alpha
+        );
+        //z
+        worldrenderer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION);
+        worldrenderer.pos(p_181561_0_.minX, p_181561_0_.maxY, p_181561_0_.minZ).endVertex();
+        worldrenderer.pos(p_181561_0_.maxX, p_181561_0_.maxY, p_181561_0_.minZ).endVertex();
+        worldrenderer.pos(p_181561_0_.maxX, p_181561_0_.minY, p_181561_0_.minZ).endVertex();
+        worldrenderer.pos(p_181561_0_.minX, p_181561_0_.minY, p_181561_0_.minZ).endVertex();
+        tessellator.draw();
+        worldrenderer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION);
+        worldrenderer.pos(p_181561_0_.minX, p_181561_0_.minY, p_181561_0_.maxZ).endVertex();
+        worldrenderer.pos(p_181561_0_.maxX, p_181561_0_.minY, p_181561_0_.maxZ).endVertex();
+        worldrenderer.pos(p_181561_0_.maxX, p_181561_0_.maxY, p_181561_0_.maxZ).endVertex();
+        worldrenderer.pos(p_181561_0_.minX, p_181561_0_.maxY, p_181561_0_.maxZ).endVertex();
+        tessellator.draw();
+    }
+
+    public static void renderBeaconBeam(BlockPos block, int rgb, float alphaMult, float partialTicks) {
+        double viewerX;
+        double viewerY;
+        double viewerZ;
+
+        Entity viewer = Minecraft.getMinecraft().getRenderViewEntity();
+        viewerX = viewer.lastTickPosX + (viewer.posX - viewer.lastTickPosX) * partialTicks;
+        viewerY = viewer.lastTickPosY + (viewer.posY - viewer.lastTickPosY) * partialTicks;
+        viewerZ = viewer.lastTickPosZ + (viewer.posZ - viewer.lastTickPosZ) * partialTicks;
+
+        double x = block.getX() - viewerX;
+        double y = block.getY() - viewerY;
+        double z = block.getZ() - viewerZ;
+
+        double distSq = x * x + y * y + z * z;
+
+        WaypointUtil.renderBeaconBeam(x, y, z, rgb, 1.0f, partialTicks, distSq > 10 * 10);
+    }
+
+    public static void renderBeaconBeamOrBoundingBox(BlockPos block, int rgb, float alphaMult, float partialTicks) {
+        double viewerX;
+        double viewerY;
+        double viewerZ;
+
+        Entity viewer = Minecraft.getMinecraft().getRenderViewEntity();
+        viewerX = viewer.lastTickPosX + (viewer.posX - viewer.lastTickPosX) * partialTicks;
+        viewerY = viewer.lastTickPosY + (viewer.posY - viewer.lastTickPosY) * partialTicks;
+        viewerZ = viewer.lastTickPosZ + (viewer.posZ - viewer.lastTickPosZ) * partialTicks;
+
+        double x = block.getX() - viewerX;
+        double y = block.getY() - viewerY;
+        double z = block.getZ() - viewerZ;
+
+        double distSq = x * x + y * y + z * z;
+
+        if (distSq > 10 * 10) {
+            WaypointUtil.renderBeaconBeam(x, y, z, rgb, 1.0f, partialTicks, true);
+        } else {
+            WaypointUtil.renderBoundingBox(x, y, z, rgb, 1.0f, partialTicks);
+        }
+    }
+
+    public static void renderWayPoint(String str, BlockPos loc, float partialTicks) {
+        renderWayPoint(str, new Vector3f(loc.getX(), loc.getY(), loc.getZ()), partialTicks);
+    }
+
+    public static void renderWayPoint(String str, Vector3f loc, float partialTicks) {
+        GlStateManager.alphaFunc(516, 0.1F);
+
+        GlStateManager.pushMatrix();
+
+        Entity viewer = Minecraft.getMinecraft().getRenderViewEntity();
+        double viewerX = viewer.lastTickPosX + (viewer.posX - viewer.lastTickPosX) * partialTicks;
+        double viewerY = viewer.lastTickPosY + (viewer.posY - viewer.lastTickPosY) * partialTicks;
+        double viewerZ = viewer.lastTickPosZ + (viewer.posZ - viewer.lastTickPosZ) * partialTicks;
+
+        double x = loc.x - viewerX + 0.5f;
+        double y = loc.y - viewerY - viewer.getEyeHeight();
+        double z = loc.z - viewerZ + 0.5f;
+
+        double distSq = x * x + y * y + z * z;
+        double dist = Math.sqrt(distSq);
+        if (distSq > 144) {
+            x *= 12 / dist;
+            y *= 12 / dist;
+            z *= 12 / dist;
+        }
+        GlStateManager.translate(x, y, z);
+        GlStateManager.translate(0, viewer.getEyeHeight(), 0);
+
+        renderNametag(str);
+
+        GlStateManager.rotate(-Minecraft.getMinecraft().getRenderManager().playerViewY, 0.0F, 1.0F, 0.0F);
+        GlStateManager.rotate(Minecraft.getMinecraft().getRenderManager().playerViewX, 1.0F, 0.0F, 0.0F);
+        GlStateManager.translate(0, -0.25f, 0);
+        GlStateManager.rotate(-Minecraft.getMinecraft().getRenderManager().playerViewX, 1.0F, 0.0F, 0.0F);
+        GlStateManager.rotate(Minecraft.getMinecraft().getRenderManager().playerViewY, 0.0F, 1.0F, 0.0F);
+
+        renderNametag(EnumChatFormatting.YELLOW.toString() + Math.round(dist) + "m");
+
+        GlStateManager.popMatrix();
+
+        GlStateManager.disableLighting();
+    }
+
+    public static void renderNametag(String str) {
+        FontRenderer fontrenderer = Minecraft.getMinecraft().fontRendererObj;
+        float f = 1.6F;
+        float f1 = 0.016666668F * f;
+        GlStateManager.pushMatrix();
+        GL11.glNormal3f(0.0F, 1.0F, 0.0F);
+        GlStateManager.rotate(-Minecraft.getMinecraft().getRenderManager().playerViewY, 0.0F, 1.0F, 0.0F);
+        GlStateManager.rotate(Minecraft.getMinecraft().getRenderManager().playerViewX, 1.0F, 0.0F, 0.0F);
+        GlStateManager.scale(-f1, -f1, f1);
+        GlStateManager.disableLighting();
+        GlStateManager.depthMask(false);
+        GlStateManager.disableDepth();
+        GlStateManager.enableBlend();
+        GlStateManager.tryBlendFuncSeparate(770, 771, 1, 0);
+        Tessellator tessellator = Tessellator.getInstance();
+        WorldRenderer worldrenderer = tessellator.getWorldRenderer();
+        int i = 0;
+
+        int j = fontrenderer.getStringWidth(str) / 2;
+        GlStateManager.disableTexture2D();
+        worldrenderer.begin(7, DefaultVertexFormats.POSITION_COLOR);
+        worldrenderer.pos(-j - 1, -1 + i, 0.0D).color(0.0F, 0.0F, 0.0F, 0.25F).endVertex();
+        worldrenderer.pos(-j - 1, 8 + i, 0.0D).color(0.0F, 0.0F, 0.0F, 0.25F).endVertex();
+        worldrenderer.pos(j + 1, 8 + i, 0.0D).color(0.0F, 0.0F, 0.0F, 0.25F).endVertex();
+        worldrenderer.pos(j + 1, -1 + i, 0.0D).color(0.0F, 0.0F, 0.0F, 0.25F).endVertex();
+        tessellator.draw();
+        GlStateManager.enableTexture2D();
+        fontrenderer.drawString(str, -fontrenderer.getStringWidth(str) / 2, i, 553648127);
+        GlStateManager.depthMask(true);
+
+        fontrenderer.drawString(str, -fontrenderer.getStringWidth(str) / 2, i, -1);
+
+        GlStateManager.enableDepth();
+        GlStateManager.enableBlend();
+        GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+        GlStateManager.popMatrix();
+    }
+}

--- a/src/main/java/cc/woverflow/hytils/util/WaypointUtil.java
+++ b/src/main/java/cc/woverflow/hytils/util/WaypointUtil.java
@@ -24,7 +24,6 @@ import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.WorldRenderer;
-import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.*;
@@ -43,7 +42,7 @@ public class WaypointUtil {
 
     private static final ResourceLocation beaconBeam = new ResourceLocation("textures/entity/beacon_beam.png");
 
-    private static void renderBeaconBeam(double x, double y, double z, int rgb, float alphaMult, float partialTicks, Boolean disableDepth) {
+    private static void renderBeaconBeam(double x, double y, double z, int rgb, float alphaMult, float partialTicks, boolean disableDepth) {
         int height = 300;
         int bottomOffset = 0;
         int topOffset = bottomOffset + height;
@@ -143,7 +142,7 @@ public class WaypointUtil {
         GlStateManager.enableDepth();
     }
 
-    public static void drawFilledBoundingBox(AxisAlignedBB p_181561_0_, float alpha, Color color) {
+    public static void drawFilledBoundingBox(AxisAlignedBB boundingBox, float alpha, Color color) {
 
         GlStateManager.enableBlend();
         GlStateManager.tryBlendFuncSeparate(770, 771, 1, 0);
@@ -156,16 +155,16 @@ public class WaypointUtil {
 
         //vertical
         worldrenderer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION);
-        worldrenderer.pos(p_181561_0_.minX, p_181561_0_.minY, p_181561_0_.minZ).endVertex();
-        worldrenderer.pos(p_181561_0_.maxX, p_181561_0_.minY, p_181561_0_.minZ).endVertex();
-        worldrenderer.pos(p_181561_0_.maxX, p_181561_0_.minY, p_181561_0_.maxZ).endVertex();
-        worldrenderer.pos(p_181561_0_.minX, p_181561_0_.minY, p_181561_0_.maxZ).endVertex();
+        worldrenderer.pos(boundingBox.minX, boundingBox.minY, boundingBox.minZ).endVertex();
+        worldrenderer.pos(boundingBox.maxX, boundingBox.minY, boundingBox.minZ).endVertex();
+        worldrenderer.pos(boundingBox.maxX, boundingBox.minY, boundingBox.maxZ).endVertex();
+        worldrenderer.pos(boundingBox.minX, boundingBox.minY, boundingBox.maxZ).endVertex();
         tessellator.draw();
         worldrenderer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION);
-        worldrenderer.pos(p_181561_0_.minX, p_181561_0_.maxY, p_181561_0_.maxZ).endVertex();
-        worldrenderer.pos(p_181561_0_.maxX, p_181561_0_.maxY, p_181561_0_.maxZ).endVertex();
-        worldrenderer.pos(p_181561_0_.maxX, p_181561_0_.maxY, p_181561_0_.minZ).endVertex();
-        worldrenderer.pos(p_181561_0_.minX, p_181561_0_.maxY, p_181561_0_.minZ).endVertex();
+        worldrenderer.pos(boundingBox.minX, boundingBox.maxY, boundingBox.maxZ).endVertex();
+        worldrenderer.pos(boundingBox.maxX, boundingBox.maxY, boundingBox.maxZ).endVertex();
+        worldrenderer.pos(boundingBox.maxX, boundingBox.maxY, boundingBox.minZ).endVertex();
+        worldrenderer.pos(boundingBox.minX, boundingBox.maxY, boundingBox.minZ).endVertex();
         tessellator.draw();
 
         GlStateManager.color(
@@ -177,16 +176,16 @@ public class WaypointUtil {
 
         //x
         worldrenderer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION);
-        worldrenderer.pos(p_181561_0_.minX, p_181561_0_.minY, p_181561_0_.maxZ).endVertex();
-        worldrenderer.pos(p_181561_0_.minX, p_181561_0_.maxY, p_181561_0_.maxZ).endVertex();
-        worldrenderer.pos(p_181561_0_.minX, p_181561_0_.maxY, p_181561_0_.minZ).endVertex();
-        worldrenderer.pos(p_181561_0_.minX, p_181561_0_.minY, p_181561_0_.minZ).endVertex();
+        worldrenderer.pos(boundingBox.minX, boundingBox.minY, boundingBox.maxZ).endVertex();
+        worldrenderer.pos(boundingBox.minX, boundingBox.maxY, boundingBox.maxZ).endVertex();
+        worldrenderer.pos(boundingBox.minX, boundingBox.maxY, boundingBox.minZ).endVertex();
+        worldrenderer.pos(boundingBox.minX, boundingBox.minY, boundingBox.minZ).endVertex();
         tessellator.draw();
         worldrenderer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION);
-        worldrenderer.pos(p_181561_0_.maxX, p_181561_0_.minY, p_181561_0_.minZ).endVertex();
-        worldrenderer.pos(p_181561_0_.maxX, p_181561_0_.maxY, p_181561_0_.minZ).endVertex();
-        worldrenderer.pos(p_181561_0_.maxX, p_181561_0_.maxY, p_181561_0_.maxZ).endVertex();
-        worldrenderer.pos(p_181561_0_.maxX, p_181561_0_.minY, p_181561_0_.maxZ).endVertex();
+        worldrenderer.pos(boundingBox.maxX, boundingBox.minY, boundingBox.minZ).endVertex();
+        worldrenderer.pos(boundingBox.maxX, boundingBox.maxY, boundingBox.minZ).endVertex();
+        worldrenderer.pos(boundingBox.maxX, boundingBox.maxY, boundingBox.maxZ).endVertex();
+        worldrenderer.pos(boundingBox.maxX, boundingBox.minY, boundingBox.maxZ).endVertex();
         tessellator.draw();
 
         GlStateManager.color(
@@ -197,16 +196,16 @@ public class WaypointUtil {
         );
         //z
         worldrenderer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION);
-        worldrenderer.pos(p_181561_0_.minX, p_181561_0_.maxY, p_181561_0_.minZ).endVertex();
-        worldrenderer.pos(p_181561_0_.maxX, p_181561_0_.maxY, p_181561_0_.minZ).endVertex();
-        worldrenderer.pos(p_181561_0_.maxX, p_181561_0_.minY, p_181561_0_.minZ).endVertex();
-        worldrenderer.pos(p_181561_0_.minX, p_181561_0_.minY, p_181561_0_.minZ).endVertex();
+        worldrenderer.pos(boundingBox.minX, boundingBox.maxY, boundingBox.minZ).endVertex();
+        worldrenderer.pos(boundingBox.maxX, boundingBox.maxY, boundingBox.minZ).endVertex();
+        worldrenderer.pos(boundingBox.maxX, boundingBox.minY, boundingBox.minZ).endVertex();
+        worldrenderer.pos(boundingBox.minX, boundingBox.minY, boundingBox.minZ).endVertex();
         tessellator.draw();
         worldrenderer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION);
-        worldrenderer.pos(p_181561_0_.minX, p_181561_0_.minY, p_181561_0_.maxZ).endVertex();
-        worldrenderer.pos(p_181561_0_.maxX, p_181561_0_.minY, p_181561_0_.maxZ).endVertex();
-        worldrenderer.pos(p_181561_0_.maxX, p_181561_0_.maxY, p_181561_0_.maxZ).endVertex();
-        worldrenderer.pos(p_181561_0_.minX, p_181561_0_.maxY, p_181561_0_.maxZ).endVertex();
+        worldrenderer.pos(boundingBox.minX, boundingBox.minY, boundingBox.maxZ).endVertex();
+        worldrenderer.pos(boundingBox.maxX, boundingBox.minY, boundingBox.maxZ).endVertex();
+        worldrenderer.pos(boundingBox.maxX, boundingBox.maxY, boundingBox.maxZ).endVertex();
+        worldrenderer.pos(boundingBox.minX, boundingBox.maxY, boundingBox.maxZ).endVertex();
         tessellator.draw();
     }
 

--- a/src/main/java/cc/woverflow/hytils/util/WaypointUtil.java
+++ b/src/main/java/cc/woverflow/hytils/util/WaypointUtil.java
@@ -43,10 +43,7 @@ public class WaypointUtil {
 
     private static final ResourceLocation beaconBeam = new ResourceLocation("textures/entity/beacon_beam.png");
 
-    private static void renderBeaconBeam(
-        double x, double y, double z, int rgb, float alphaMult,
-        float partialTicks, Boolean disableDepth
-    ) {
+    private static void renderBeaconBeam(double x, double y, double z, int rgb, float alphaMult, float partialTicks, Boolean disableDepth) {
         int height = 300;
         int bottomOffset = 0;
         int topOffset = bottomOffset + height;


### PR DESCRIPTION
## Description

Main
- Add center beacon for MiniWalls
- Add center waypoint for (Speed) UHC
- Add a /limbo command (needs to be fixed to take precedence over AutoTip and maybe remove the error message that comes with using this method but that's not as important
- Add starting code to lower render distance in sumo (needs to be reworked)
- Add Replay Recorded hider (I think it works)
- Add Tip Messager hider (works)
- Add Online Status hider (works)
- Add View Recents Stats hider (probably works)
- Add Game Tips hider (probably works - tested two)
- Replace Booster, GEXP, and Time Played hider with Earned Coins and Exp hider (probably works)

**Please do not merge yet!** Hiders need to be tested.

<details>
	<summary>Old Stuff:</summary>

There are a few ideas/changes that should be thought about first. Will be updated regularly

- I'd like to make waypoints for all gamemodes where it makes sense. Some examples:
  - BedWars teams/gens
  - MegaWalls mid/withers
  - SW mid (?)
  - etc.
- If we go down this path of making for all/more gamemodes, it might make sense to move this all into its own category  

</details>

(I'd rather look at this stuff more in the future and not right now)