### PR TITLE
fix sumo

### DIFF
--- a/src/main/java/cc/woverflow/hytils/HytilsReborn.java
+++ b/src/main/java/cc/woverflow/hytils/HytilsReborn.java
@@ -197,7 +197,7 @@ public class HytilsReborn {
         eventBus.register(new HousingMusic());
         eventBus.register(new GameStartingTitles());
         eventBus.register(new GoalArmorStands());
-        // eventBus.register(new SumoRenderDistance());
+        eventBus.register(new SumoRenderDistance());
         eventBus.register(new MiddleBeaconMiniWalls());
         eventBus.register(new MiddleWaypointUHC());
 

--- a/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
+++ b/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
@@ -728,7 +728,6 @@ public class HytilsConfig extends Vigilant {
     )
     public static String uhcMiddleWaypointText = "0,0";
 
-    /*
     @Property(
         type = PropertyType.SWITCH, name = "Lower Render Distance in Sumo",
         description = "Lowers render distance to your desired value in sumo duels.",
@@ -743,7 +742,6 @@ public class HytilsConfig extends Vigilant {
         min = 1, max = 5
     )
     public static int sumoRenderDistanceAmount = 2;
-     */
 
     @Property(
         type = PropertyType.SWITCH, name = "Hide Armor",
@@ -996,7 +994,7 @@ public class HytilsConfig extends Vigilant {
 
         addDependency("uhcMiddleWaypointText", "uhcMiddleWaypoint");
 
-        // addDependency("sumoRenderDistanceAmount", "sumoRenderDistance");
+        addDependency("sumoRenderDistanceAmount", "sumoRenderDistance");
 
         addDependency("overlayAmount", "heightOverlay");
 

--- a/src/main/java/cc/woverflow/hytils/handlers/game/duels/SumoRenderDistance.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/game/duels/SumoRenderDistance.java
@@ -24,23 +24,36 @@ import cc.woverflow.hytils.util.locraw.LocrawInformation;
 import gg.essential.api.EssentialAPI;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.settings.GameSettings;
+import net.minecraftforge.client.event.RenderWorldEvent;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
+import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 public class SumoRenderDistance {
-    /*
     final GameSettings gs = Minecraft.getMinecraft().gameSettings;
-    final int oldRd = gs.renderDistanceChunks;
+    int resetRd = gs.renderDistanceChunks;
+    boolean wasSumo = false;
+    boolean isFirstRender = true;
 
     @SubscribeEvent
-    public void onRenderWorld(RenderWorldLastEvent event) {
+    public void onWorldLoad(RenderWorldLastEvent event) {
         LocrawInformation locraw = HytilsReborn.INSTANCE.getLocrawUtil().getLocrawInformation();
         if (HytilsConfig.sumoRenderDistance && EssentialAPI.getMinecraftUtil().isHypixel() && (locraw != null && locraw.getGameMode().contains("SUMO"))) {
-            gs.renderDistanceChunks = HytilsConfig.sumoRenderDistanceAmount;
+            if (isFirstRender) {
+                final int oldRd = gs.renderDistanceChunks;
+                wasSumo = true;
+                gs.renderDistanceChunks = HytilsConfig.sumoRenderDistanceAmount;
+                resetRd = oldRd;
+            }
+            isFirstRender = false;
         }
         else {
-            gs.renderDistanceChunks = oldRd;
+            if (wasSumo) {
+                wasSumo = false;
+                isFirstRender = true;
+                gs.renderDistanceChunks = resetRd;
+
+            }
         }
     }
-     */
 }

--- a/src/main/java/cc/woverflow/hytils/handlers/language/LanguageData.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/language/LanguageData.java
@@ -54,7 +54,7 @@ public class LanguageData {
     public String chatCleanerReplyRecorded = "This game has been recorded. Click here to watch the Replay!";
     private String chatCleanerTip = "(?:You tipped \\d+ (?:player|players) in \\d+ (?:game|different games)!|You already tipped everyone that has boosters active, so there isn't anybody to be tipped right now!)";
     private String chatCleanerOnlineStatus = "REMINDER: Your Online Status is currently set to (?:Appear Offline|Busy|Away)";
-    private String chatCleanerGameTips = "^(?:If you get disconnected use /rejoin to join back in the game.|You may use /mmreport <skin name> to chat report in this mode!|Teaming with the *.+ is not allowed!|Teaming is not allowed *.+|Cross Teaming / Teaming with other teams is not allowed!|Cross-teaming is not allowed! Report cross-teamers using /report.|Cages opened! FIGHT!)";
+    private String chatCleanerGameTips = "^(?:If you get disconnected use /rejoin to join back in the game.|You may use /mmreport <skin name> to chat report in this mode!|Teaming with the *.+ is not allowed!|Teaming is not allowed *.+|Cross Teaming / Teaming with other teams is not allowed!|Cross-teaming is not allowed! Report cross-teamers using /report.|Cages opened! FIGHT!|Queued! Use the bed to return to lobby!|Queued! Use the bed to cancel!)";
     private String chatCleanerStats = "Click to view the stats of your \\S+ game!";
 
     private String connectedServerConnectMessage = "^(You are currently connected to server \\S+)|(Sending you to \\S+.{3}!)|(Sending to server \\S+.{3})|(Warping you to your Skyblock island...)|(Warping...)|(Sending a visit request...)|(Finding player...)$";


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This is probably extremely inefficient but it was the only way I was able to get it to work. RenderWorldLastEvent fires every tick or something, which was what was screwing me over in the beginning as I didn't know it did that. I added a check to only do stuff on the first fire. The old implementation also meant that it was impossible to change render distance at all. This has been fixed so that resetting render distance only happens if you have just come out of sumo. I also tested directly queueing another sumo after the first one ends and saw no problems there, so this shouldn't cause any issues.

The only possible issues I can think of are Alt-F4'ing the game while in a sumo match or getting the bug where Minecraft sometimes doesn't save changes if you leave the game quickly afterward.

Also, I added some more stuff to Game Tips Hider.
