### PR TITLE
hide armor in uhc duels

### DIFF
--- a/src/main/java/cc/woverflow/hytils/mixin/LayerArmorBaseMixin_HideIngameArmour.java
+++ b/src/main/java/cc/woverflow/hytils/mixin/LayerArmorBaseMixin_HideIngameArmour.java
@@ -61,7 +61,7 @@ public abstract class LayerArmorBaseMixin_HideIngameArmour {
                 }
             } else {
                 if (locraw.getGameType() == LocrawInfo.GameType.DUELS) {
-                    return locraw.getGameMode().contains("CLASSIC");
+                    return locraw.getGameMode().contains("CLASSIC") || locraw.getGameMode().contains("UHC");
                 }
             }
         }


### PR DESCRIPTION
despite the fact that armor in uhc is always the same, it was not hidden with the setting. realistically no armor piece will ever break in duels uhc so that isn't an issue

despite playing so much uhc duels I never realized this issue till 5 mins ago lol