### PR TITLE
fix short channel names and colored friend statuses incompatibility

### DIFF
--- a/src/main/java/cc/woverflow/hytils/handlers/chat/modules/modifiers/ColoredFriendStatuses.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/chat/modules/modifiers/ColoredFriendStatuses.java
@@ -34,11 +34,22 @@ public class ColoredFriendStatuses implements ChatReceiveModule {
             Matcher matcher = getLanguage().chatRestylerStatusPatternRegex.matcher(message);
             if (matcher.matches()) {
                 final String status = matcher.group("status"); // TODO: fix short channel names so we can remove the 2nd group
+
+                String channelStarter = null; // Fixes short channel name incompatibility since it randomly popped up despite what appears to be no changes
+                if (matcher.group("type").contains("F")) {
+                    if (HytilsConfig.shortChannelNames) channelStarter = "§aF > §r";
+                    else channelStarter = "§aFriend > §r";
+                }
+                if (matcher.group("type").contains("G")) {
+                    if (HytilsConfig.shortChannelNames) channelStarter = "§2G > §r";
+                    else channelStarter = "§2Guild > §r";
+                }
+
                 if (status.equalsIgnoreCase("joined")) {
-                    event.message = colorMessage(matcher.group("type") + " > §r" + matcher.group("player") + " §r" + "§ajoined§e.");
+                    event.message = colorMessage(channelStarter + matcher.group("player") + " §r" + "§ajoined§e.");
                 }
                 if (status.equalsIgnoreCase("left")) {
-                    event.message = colorMessage(matcher.group("type") + " > §r" + matcher.group("player") + " §r" + "§cleft§e.");
+                    event.message = colorMessage(channelStarter + matcher.group("player") + " §r" + "§cleft§e.");
                 }
             }
         }


### PR DESCRIPTION
## Description
Since we reconstruct the message for Colored Friend Statuses, just taking into account whether we should use the short or long form is pretty easy to redo. Granted this isn't a proper fix really, but I could not figure out why it was broken as it worked before and nothing changed as far as I can tell.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #42 

## How to test
Turn on both features and see if they work together

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Fix incompatibility with Colored Friend Statuses and Short Channel Names
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->