### PR TITLE
misc: re-added descriptions to the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,12 @@ If you do not know how to install a Forge mod, then we recommend following [this
 
 ## Automatic
 - **Automatically Get API Key** - Automatically get the API Key from /api new.
-- **Auto GL** - Send a message 5 seconds before a Hypixel game starts.
-- **Anti GL** - Remove all GL messages from chat.
-- **Auto Chat Report Confirm** - Automatically confirms chat reports.
-- **Auto Party Warp Confirm** - Automatically confirms party warps.
+- **Auto Start** - Join Hypixel immediately once the client has loaded to the main menu.
 - **Auto Queue** - Automatically queues for another game once you win or die. (This will require you to interact with the game in a way to prevent abuse)
 - **Auto-Complete Play Commands** - Allows tab completion of /play commands.
 - **Limbo Play Helper** - When a /play command is run in Limbo, this runs /l first and then the command.
-- **Auto Start** - Join Hypixel immediately once the client has loaded to the main menu.
+- **Auto GL** - Send a message 5 seconds before a Hypixel game starts.
+- **Anti GL** - Remove all GL messages from chat.
 - **Auto Friend** - Automatically accept friend requests.
 - **Automatically Check GEXP** - Automatically check your GEXP after you win a Hypixel game.
 - **Automatically Check Winstreak** - Automatically check your winstreak after you win a Hypixel game.
@@ -40,8 +38,9 @@ If you do not know how to install a Forge mod, then we recommend following [this
   <summary>Chat</summary>
 
 # Chat
+- **Hide Locraw Messages** - Hide locraw messages in chat.
 - **Remove Lobby Statuses** - Remove lobby join messages from chat.
-- **Remove Other's Mystery Box Rewards** - Remove others mystery box messages from chat and only show your own.
+- **Remove Mystery Box Rewards** - Remove others mystery box messages from chat and only show your own.
 - **Remove Soul Well Announcements** - Remove soul well announcements from chat.
 - **Remove Game Announcements** - Remove game announcements from chat.
 - **Remove Hype Limit Reminder** - Remove Hype limit reminders from chat.
@@ -51,7 +50,9 @@ If you do not know how to install a Forge mod, then we recommend following [this
 - **Remove Guild MOTD** - Remove the guild Message Of The Day.
 - **Remove Chat Emojis** - Remove MVP++ chat emojis.
 - **Remove Server Connected Messages** - Remove messages informing you of the lobby name you've just joined, or what lobby you're being sent to.
+- **Remove Game Tips Messages** - Remove messages informing you of how to play the game you're currently in.
 - **Remove Auto Activated Quest Messages** - Remove automatically activated quest messages.
+- **Remove Stats Messages** - Remove messages informing you if you want to view your stats after a game.
 - **Remove Curse of Spam Messages** - Hides the constant spam of Kali's curse of spam.
 - **Remove Bridge Self Goal Death Messages** - Hides the death message when you jump into your own goal in Bridge.
 - **Remove Duels No Stats Change Messages** - Hides the message explaining that your stats did not change for dueling through /duel or within in a party.
@@ -63,11 +64,11 @@ If you do not know how to install a Forge mod, then we recommend following [this
 - **Remove Replay Messages** - Removes replay messages from chat.
 - **Remove Tip Messages** - Removes tip messages from chat.
 - **Remove Online Status Messages** - Removes the online status messages from chat.
-- **AutoWB** - Says configurable message to your friends/guild when they join.
 - **Trim Line Separators** - Prevent separators from overflowing onto the next chat line.
 - **Clean Line Separators** - Change all line separator to become smoother.
 - **White Chat** - Make nons' chat messages appear as the normal chat message color.
 - **White Private Messages** - Make private messages appear as the normal chat message color.
+- **Colored Friend/Guild Statuses** - Colors the join/leave status of friends and guild members.
 - **Cleaner Game Start Counter** - Compacts game start announcements.
 - **Short Channel Names** - Abbreviate chat channel names.
 - **Game Status Restyle** - Replace common game status messages with a new style.
@@ -78,35 +79,35 @@ If you do not know how to install a Forge mod, then we recommend following [this
 - **Swap Chatting Tab With Chat Swapper** - Automatically switch your [Chatting](https://github.com/Polyfrost/Chatting) chat tab when chat swapper swaps your chat channel.
 - **Remove All Chat Message** - Hide the "You are now in the ALL channel" message when auto-switching.
 - **Thank Watchdog** - Compliment Watchdog when someone is banned, or a Watchdog announcement is sent.
+- **Auto Chat Report Confirm** - Automatically confirms chat reports.
+- **Auto Party Warp Confirm** - Automatically confirms party warps.
 - **Guild Welcome Message** - Send a friendly welcome message when a player joins your guild.
 - **Shout Cooldown** - Show the amount of time remaining until /shout can be reused.
 - **Non Speech Cooldown** - Show the amount of time remaining until you can speak if you are a non.
+- **AutoWB** - Says configurable message to your friends/guild when they join.
 </details>
 <details>
   <summary>General</summary>
   
 # General
-- **Broadcast Achievements** - Announce in Guild chat when you get an achievement.
-- **Broadcast Levelup** - Announce in Guild chat when you level up.
 - **Notify Mining Fatigue** - Send a notification when you get mining fatigue.
 - **Disable Mining Fatigue Notification in SkyBlock** - Disable the mining fatigue notification in SkyBlock.
 - **Hide NPCs In Tab** - Prevent NPCs from showing up in tab.
 - **Don't Hide Important NPCs** - Keeps NPCs in tab in gamemodes like SkyBlock and Replay.
 - **Hide Guild Tags in Tab** - Prevent Guild tags from showing up in tab.
 - **Hide Player Ranks in Tab** - Prevent player ranks from showing up in tab.
-- **Hide Guild Tags In Tab** - Prevent Guild tags from showing up in tab.
 - **Highlight Friends In Tab** - Add a star to the names of your Hypixel friends in tab.
 - **Highlight Self In Tab** - Add a star to your name in tab.
 - **Cleaner Tab in SkyBlock** - Doesn't render player heads or ping for tab entries that aren't players in SkyBlock.
 - **Hide Ping in Tab** - Prevent ping from showing up in tab while playing games, since the value is misleading. Ping will remain visible in lobbies.
+- **Broadcast Achievements** - Announce in Guild chat when you get an achievement.
+- **Broadcast Levelup** - Announce in Guild chat when you level up.
 </details>
 <details>
   <summary>Game</summary>
 
 # Game
 - **Notify When Kicked From Game** - Notify in party chat when you are kicked from the game due to a connection issue.
-- **Mute Housing Music** - Prevent the Housing songs from being heard.
-- **Notify When Blocks Run Out** - Pings you via a sound when your blocks are running out.
 - **Highlight Opened Chests** - Highlight chests that have been opened.
 - **UHC Overlay** - Increase the size of dropped apples, golden apples, golden ingots, and player heads in UHC Champions and Speed UHC.
 - **UHC Middle Waypoint** - Adds a waypoint to signify (0,0).
@@ -118,11 +119,14 @@ If you do not know how to install a Forge mod, then we recommend following [this
 - **Hide Game Starting Titles** - Hide titles such as the countdown when a game is about to begin and gamemode names.
 - **Hide Game Ending Titles** - Hide titles that signify when the game has ended.
 - **Hide Game Ending Countdown Titles** - Hide titles that signify the time left in a game.
-- **Height Overlay** - Make blocks that are in the Hypixel height limit a different colour.
+- **Height Overlay** - Make blocks that are in the Hypixel height limit a different color.
 - **Hide Duels Cosmetics** - Hide Duels Cosmetics in Hypixel.
 - **Hide Actionbar in Housing** - Hide the Actionbar in Housing.
+- **Hide Actionbar in Dropper** - Hide the Actionbar in Dropper.
 - **Remove Non-NPCs in SkyBlock** - Remove entities that are not NPCs in SkyBlock.
 - **Middle Waypoint Beacon in MiniWalls** - Adds a beacon at (0,0) when your MiniWither is dead in MiniWalls.
+- **Mute Housing Music** - Prevent the Housing songs from being heard.
+- **Notify When Blocks Run Out** - Pings you via a sound when your blocks are running out.
 </details>
 <details>
   <summary>Lobby</summary>
@@ -130,11 +134,11 @@ If you do not know how to install a Forge mod, then we recommend following [this
 # Lobby
 - **Hide Lobby NPCs** - Hide NPCs in the lobby.
 - **Hide Useless Lobby Nametags** - Hides unnecessary nametags such as those that say "RIGHT CLICK" or "CLICK TO PLAY" in a lobby, as well as other useless ones.
-- **Hide Lobby Bossbars** - Hide the bossbar in the lobby.
-- **Mystery Box Star** - Shows what star a mystery box is in the Mystery Box Vault, Orange stars are special boxes.
 - **Remove Limbo AFK Title** - Remove the AFK title when you get sent to limbo for being AFK.
 - **Limbo Limiter** - While in Limbo, limit your framerate to reduce the load of the game on your computer.
 - **Limbo PM Ding** - While in Limbo, play the ding sound if you get a PM. Currently, Hypixel's option does not work in Limbo.
+- **Hide Lobby Bossbars** - Hide the bossbar in the lobby.
+- **Mystery Box Star** - Shows what star a mystery box is in the Mystery Box Vault, Orange stars are special boxes.
 </details>
 
 ### LICENSING UPDATE

--- a/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
+++ b/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
@@ -143,7 +143,7 @@ public class HytilsConfig extends Config {
 
     @Switch(
         name = "Hide Locraw Messages",
-        description = "Hide Locraw Messages",
+        description = "Hide Locraw Messages.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean hideLocraw = true;
@@ -241,7 +241,7 @@ public class HytilsConfig extends Config {
 
     @Switch(
         name = "Remove Stats Messages",
-        description = "Remove messages informing you if you want to view your stats after a game",
+        description = "Remove messages informing you if you want to view your stats after a game.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean statsMessages;

--- a/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
+++ b/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
@@ -45,6 +45,7 @@ public class HytilsConfig extends Config {
 
     @Text(
         name = "API Key",
+        description = "Automatically get the API Key from /api new.",
         category = "API",
         secure = true
     )
@@ -55,12 +56,14 @@ public class HytilsConfig extends Config {
 
     @Switch(
         name = "Auto Start",
+        description = "Join Hypixel immediately once the client has loaded to the main menu.",
         category = "Automatic", subcategory = "General"
     )
     public static boolean autoStart;
 
     @Switch(
         name = "Auto Queue",
+        description = "Automatically queues for another game once you win or die. (This will require you to interact with the game in a way to prevent abuse)",
         category = "Automatic", subcategory = "Game"
     )
     public static boolean autoQueue;
@@ -74,18 +77,21 @@ public class HytilsConfig extends Config {
 
     @Switch(
         name = "Auto-Complete Play Commands",
+        description = "Allows tab completion of /play commands.",
         category = "Automatic", subcategory = "Game"
     )
     public static boolean autocompletePlayCommands;
 
     @Switch(
         name = "Limbo Play Helper",
+        description = "When a /play command is run in Limbo, this runs /l first and then the command.",
         category = "Automatic", subcategory = "Game"
     )
     public static boolean limboPlayCommandHelper;
 
     @Switch(
         name = "Auto GL",
+        description = "Send a message 5 seconds before a Hypixel game starts.",
         category = "Automatic", subcategory = "AutoGL"
     )
     public static boolean autoGL;
@@ -99,18 +105,21 @@ public class HytilsConfig extends Config {
 
     @Switch(
         name = "Anti GL",
+        description = "Remove all GL messages from chat.",
         category = "Automatic", subcategory = "AutoGL"
     )
     public static boolean antiGL;
 
     @Switch(
         name = "Auto Friend",
+        description = "Automatically accept friend requests.",
         category = "Automatic", subcategory = "Social"
     )
     public static boolean autoFriend;
 
     @Switch(
         name = "Automatically Check GEXP",
+        description = "Automatically check your GEXP after you win a Hypixel game.",
         category = "Automatic", subcategory = "Stats"
     )
     public static boolean autoGetGEXP;
@@ -125,6 +134,7 @@ public class HytilsConfig extends Config {
 
     @Switch(
         name = "Automatically Check Winstreak",
+        description = "Automatically check your winstreak after you win a Hypixel game.",
         category = "Automatic", subcategory = "Stats"
     )
     public static boolean autoGetWinstreak;
@@ -133,228 +143,266 @@ public class HytilsConfig extends Config {
 
     @Switch(
         name = "Hide Locraw Messages",
+        description = "Hide Locraw Messages",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean hideLocraw = true;
 
     @Switch(
         name = "Remove Lobby Statuses",
+        description = "Remove lobby join messages from chat.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean lobbyStatus;
 
     @Switch(
         name = "Remove Mystery Box Rewards",
+        description = "Remove others mystery box messages from chat and only show your own.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean mysteryBoxAnnouncer;
 
     @Switch(
         name = "Remove Soul Well Announcements",
+        description = "Remove soul well announcements from chat.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean soulWellAnnouncer;
 
     @Switch(
         name = "Remove Game Announcements",
+        description = "Remove game announcements from chat.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean gameAnnouncements;
 
     @Switch(
         name = "Remove Hype Limit Reminder",
+        description = "Remove Hype limit reminders from chat.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean hypeLimitReminder;
 
     @Switch(
         name = "Player AdBlocker",
+        description = "Remove spam messages from players, usually advertising something or begging for ranks.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean playerAdBlock;
 
     @Switch(
         name = "Remove BedWars Advertisements",
+        description = "Remove player messages asking to join BedWars parties.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean bedwarsAdvertisements;
 
     @Switch(
         name = "Remove Friend/Guild Statuses",
+        description = "Remove join/quit messages from friend/guild members.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean connectionStatus;
 
     @Switch(
         name = "Remove Guild MOTD",
+        description = "Remove the guild Message Of The Day.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean guildMotd;
 
     @Switch(
         name = "Remove Chat Emojis",
+        description = "Remove MVP++ chat emojis.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean mvpEmotes;
 
     @Switch(
         name = "Remove Server Connected Messages",
+        description = "Remove messages informing you of the lobby name you've just joined, or what lobby you're being sent to.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean serverConnectedMessages;
 
     @Switch(
         name = "Remove Game Tips Messages",
+        description = "Remove messages informing you of how to play the game you're currently in.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean gameTipMessages;
 
     @Switch(
         name = "Remove Auto Activated Quest Messages",
+        description = "Remove automatically activated quest messages.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean questsMessages;
 
     @Switch(
         name = "Remove Stats Messages",
+        description = "Remove messages informing you if you want to view your stats after a game",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean statsMessages;
 
     @Switch(
         name = "Remove Curse of Spam Messages",
+        description = "Hides the constant spam of Kali's curse of spam.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean curseOfSpam;
 
     @Switch(
         name = "Remove Bridge Self Goal Death Messages",
+        description = "Hides the death message when you jump into your own goal in Bridge.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean bridgeOwnGoalDeath;
 
     @Switch(
         name = "Remove Duels No Stats Change Messages",
+        description = "Hides the message explaining that your stats did not change for dueling through /duel or within in a party.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean duelsNoStatsChange;
 
     @Switch(
         name = "Remove Block Trail Disabled Messages",
+        description = "Hides the message explaining that your duel's block trail cosmetic was disabled in specific gamemodes.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean duelsBlockTrail;
 
     @Switch(
         name = "Remove SkyBlock Welcome Messages",
+        description = "Removes \"Welcome to Hypixel SkyBlock!\" messages from chat.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean skyblockWelcome;
 
     @Switch(
         name = "Remove Gift Messages",
+        description = "Removes \"They have gifted x so far!\" messages from chat.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean giftBlocker;
 
     @Switch(
         name = "Remove Seasonal Simulator Collection Messages",
+        description = "Removes personal and global collected messages from chat for the Easter, Christmas, and Halloween variants.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean grinchPresents;
 
     @Switch(
         name = "Remove Earned Coins and Experience Messages",
+        description = "Removes the earned coins and experience messages from chat.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean earnedCoinsAndExp;
 
     @Switch(
         name = "Remove Replay Messages",
+        description = "Removes replay messages from chat.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean replayMessage;
 
     @Switch(
         name = "Remove Tip Messages",
+        description = "Removes tip messages from chat.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean tipMessage;
 
     @Switch(
         name = "Remove Online Status Messages",
+        description = "Removes the online status messages from chat.",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean onlineStatus;
 
     @Switch(
         name = "Trim Line Separators",
+        description = "Prevent separators from overflowing onto the next chat line.",
         category = "Chat", subcategory = "Visual"
     )
     public static boolean lineBreakerTrim = true;
 
     @Switch(
         name = "Clean Line Separators",
+        description = "Change all line separator to become smoother.",
         category = "Chat", subcategory = "Visual"
     )
     public static boolean cleanLineSeparator = true;
 
     @Switch(
         name = "White Chat",
+        description = "Make nons' chat messages appear as the normal chat message color.",
         category = "Chat", subcategory = "Visual"
     )
     public static boolean whiteChat;
 
     @Switch(
         name = "White Private Messages",
+        description = "Make private messages appear as the normal chat message color.",
         category = "Chat", subcategory = "Visual"
     )
     public static boolean whitePrivateMessages;
 
     @Switch(
         name = "Colored Friend/Guild Statuses",
+        description = "Colors the join/leave status of friends and guild members.",
         category = "Chat", subcategory = "Visual"
     )
     public static boolean coloredStatuses;
 
     @Switch(
         name = "Cleaner Game Start Counter",
+        description = "Compacts game start announcements.",
         category = "Chat", subcategory = "Visual"
     )
     public static boolean cleanerGameStartAnnouncements;
 
     @Switch(
         name = "Short Channel Names",
+        description = "Abbreviate chat channel names.",
         category = "Chat", subcategory = "Visual"
     )
     public static boolean shortChannelNames;
 
     @Switch(
         name = "Game Status Restyle",
+        description = "Replace common game status messages with a new style.",
         category = "Chat", subcategory = "Restyler"
     )
     public static boolean gameStatusRestyle;
 
     @Switch(
         name = "Player Count Before Player Name",
+        description = "Put the player count before the player name in game join/leave messages.",
         category = "Chat", subcategory = "Restyler"
     )
     public static boolean playerCountBeforePlayerName;
 
     @Switch(
         name = "Player Count on Player Leave",
+        description = "Include the player count when players leave.",
         category = "Chat", subcategory = "Restyler"
     )
     public static boolean playerCountOnPlayerLeave;
 
     @Switch(
         name = "Player Count Padding",
+        description = "Place zeros at the beginning of the player count to align with the max player count.",
         category = "Chat", subcategory = "Restyler"
     )
     public static boolean padPlayerCount;
 
     @Switch(
         name = "Party Chat Swapper",
+        description = "Automatically change to and out of a party channel when joining/leaving a party.",
         category = "Chat", subcategory = "Parties"
     )
     public static boolean chatSwapper;
@@ -368,48 +416,56 @@ public class HytilsConfig extends Config {
 
     @Switch(
         name = "Swap Chatting Tab With Chat Swapper",
+        description = " Automatically switch your Chatting chat tab when chat swapper swaps your chat channel.",
         category = "Chat", subcategory = "Parties"
     )
     public static boolean chattingIntegration;
 
     @Switch(
         name = "Remove All Chat Message",
+        description = "Hide the \"You are now in the ALL channel\" message when auto-switching.",
         category = "Chat", subcategory = "Parties"
     )
     public static boolean hideAllChatMessage;
 
     @Switch(
         name = "Thank Watchdog",
+        description = "Compliment Watchdog when someone is banned, or a Watchdog announcement is sent.",
         category = "Chat", subcategory = "Watchdog"
     )
     public static boolean thankWatchdog;
 
     @Switch(
         name = "Auto Chat Report Confirm",
+        description = "Automatically confirms chat reports.",
         category = "Automatic", subcategory = "Chat"
     )
     public static boolean autoChatReportConfirm;
 
     @Switch(
         name = "Auto Party Warp Confirm",
+        description = "Automatically confirms party warps.",
         category = "Automatic", subcategory = "Chat"
     )
     public static boolean autoPartyWarpConfirm;
 
     @Switch(
         name = "Guild Welcome Message",
+        description = "Send a friendly welcome message when a player joins your guild.",
         category = "Chat", subcategory = "Guild"
     )
     public static boolean guildWelcomeMessage;
 
     @Switch(
         name = "Shout Cooldown",
+        description = "Show the amount of time remaining until /shout can be reused.",
         category = "Chat", subcategory = "Cooldown"
     )
     public static boolean preventShoutingOnCooldown;
 
     @Switch(
         name = "Non Speech Cooldown",
+        description = "Show the amount of time remaining until you can speak if you are a non.",
         category = "Chat", subcategory = "Cooldown"
     )
     public static boolean preventNonCooldown;
@@ -418,6 +474,7 @@ public class HytilsConfig extends Config {
 
     @Switch(
         name = "AutoWB",
+        description = "Says configurable message to your friends/guild when they join.",
         category = "Chat", subcategory = "AutoWB"
     )
     public static boolean autoWB = false;
@@ -522,42 +579,49 @@ public class HytilsConfig extends Config {
 
     @Switch(
         name = "Notify Mining Fatigue",
+        description = "Send a notification when you get mining fatigue.",
         category = "General", subcategory = "Potion Effects"
     )
     public static boolean notifyMiningFatigue;
 
     @Switch(
         name = "Disable Mining Fatigue Notification in SkyBlock",
+        description = "Disable the mining fatigue notification in SkyBlock.",
         category = "General", subcategory = "Potion Effects"
     )
     public static boolean disableNotifyMiningFatigueSkyblock;
 
     @Switch(
         name = "Hide NPCs in Tab",
+        description = "Prevent NPCs from showing up in tab.",
         category = "General", subcategory = "Tab"
     )
     public static boolean hideNpcsInTab;
 
     @Switch(
         name = "Don't Hide Important NPCs",
+        description = "Keeps NPCs in tab in gamemodes like SkyBlock and Replay.",
         category = "General", subcategory = "Tab"
     )
     public static boolean keepImportantNpcsInTab;
 
     @Switch(
         name = "Hide Guild Tags in Tab",
+        description = "Prevent Guild tags from showing up in tab.",
         category = "General", subcategory = "Tab"
     )
     public static boolean hideGuildTagsInTab;
 
     @Switch(
         name = "Hide Player Ranks in Tab",
+        description = "Prevent player ranks from showing up in tab.",
         category = "General", subcategory = "Tab"
     )
     public static boolean hidePlayerRanksInTab;
 
     @Dropdown(
         name = "Highlight Friends In Tab",
+        description = "Add a star to the names of your Hypixel friends in tab.",
         category = "General", subcategory = "Tab",
         options = {"Off", "Left of Name", "Right of Name"}
     )
@@ -565,6 +629,7 @@ public class HytilsConfig extends Config {
 
     @Dropdown(
         name = "Highlight Self In Tab",
+        description = "Add a star to your name in tab.",
         category = "General", subcategory = "Tab",
         options = {"Off", "Left of Name", "Right of Name"}
     )
@@ -572,24 +637,28 @@ public class HytilsConfig extends Config {
 
     @Switch(
         name = "Cleaner Tab in SkyBlock",
+        description = "Doesn't render player heads or ping for tab entries that aren't players in SkyBlock.",
         category = "General", subcategory = "Tab"
     )
     public static boolean cleanerSkyblockTabInfo;
 
     @Switch(
         name = "Hide Ping in Tab",
+        description = "Prevent ping from showing up in tab while playing games, since the value is misleading. Ping will remain visible in lobbies.",
         category = "General", subcategory = "Tab"
     )
     public static boolean hidePingInTab;
 
     @Switch(
         name = "Broadcast Achievements",
+        description = "Announce in Guild chat when you get an achievement.",
         category = "General", subcategory = "Guilds"
     )
     public static boolean broadcastAchievements;
 
     @Switch(
         name = "Broadcast Levelup",
+        description = "Announce in Guild chat when you level up.",
         category = "General", subcategory = "Guilds"
     )
     public static boolean broadcastLevelup;
@@ -598,6 +667,7 @@ public class HytilsConfig extends Config {
 
     @Switch(
         name = "Notify When Kicked From Game",
+        description = "Notify in party chat when you are kicked from the game due to a connection issue.",
         category = "Game", subcategory = "Chat"
     )
     public static boolean notifyWhenKick;
@@ -610,6 +680,7 @@ public class HytilsConfig extends Config {
 
     @Switch(
         name = "Highlight Opened Chests",
+        description = "Highlight chests that have been opened.",
         category = "Game", subcategory = "Visual"
     )
     public static boolean highlightChests;
@@ -622,6 +693,7 @@ public class HytilsConfig extends Config {
 
     @Switch(
         name = "UHC Overlay",
+        description = "Increase the size of dropped apples, golden apples, golden ingots, and player heads in UHC Champions and Speed UHC.",
         category = "Game", subcategory = "Visual"
     )
     public static boolean uhcOverlay;
@@ -635,6 +707,7 @@ public class HytilsConfig extends Config {
 
     @Switch(
         name = "UHC Middle Waypoint",
+        description = "Adds a waypoint to signify (0,0).",
         category = "Game", subcategory = "Visual"
     )
     public static boolean uhcMiddleWaypoint;
@@ -647,6 +720,7 @@ public class HytilsConfig extends Config {
 
     @Switch(
         name = "Lower Render Distance in Sumo",
+        description = "Lowers render distance to your desired value in Sumo Duels.",
         category = "Game", subcategory = "Visual"
     )
     public static boolean sumoRenderDistance;
@@ -660,48 +734,56 @@ public class HytilsConfig extends Config {
 
     @Switch(
         name = "Hide Armor",
+        description = "Hide armor in games where armor is always the same.",
         category = "Game", subcategory = "Visual"
     )
     public static boolean hideArmor;
 
     @Switch(
         name = "Hide Useless Game Nametags",
+        description = "Hides unnecessary nametags such as those that say \"RIGHT CLICK\" or \"CLICK\" in SkyBlock, BedWars, SkyWars, and Duels, as well as other useless ones.",
         category = "Game", subcategory = "Visual"
     )
     public static boolean hideUselessArmorStandsGame;
 
     @Switch(
         name = "Hardcore Hearts",
+        description = "When your bed is broken/wither is killed in Bedwars/The Walls, set the heart style to Hardcore.",
         category = "Game", subcategory = "Visual"
     )
     public static boolean hardcoreHearts;
 
     @Switch(
         name = "Pit Lag Reducer",
+        description = "Hide entities at spawn while you are in the PVP area.",
         category = "Game", subcategory = "Visual"
     )
     public static boolean pitLagReducer;
 
     @Switch(
         name = "Hide Game Starting Titles",
+        description = "Hide titles such as the countdown when a game is about to begin and gamemode names.",
         category = "Game", subcategory = "Visual"
     )
     public static boolean hideGameStartingTitles;
 
     @Switch(
         name = "Hide Game Ending Titles",
+        description = "Hide titles that signify when the game has ended.",
         category = "Game", subcategory = "Visual"
     )
     public static boolean hideGameEndingTitles;
 
     @Switch(
         name = "Hide Game Ending Countdown Titles",
+        description = "Hide titles that signify the time left in a game.",
         category = "Game", subcategory = "Visual"
     )
     public static boolean hideGameEndingCountdownTitles;
 
     @Switch(
         name = "Height Overlay",
+        description = "Make blocks that are in the Hypixel height limit a different color.",
         category = "Game", subcategory = "Visual"
     )
     public static boolean heightOverlay;
@@ -728,30 +810,35 @@ public class HytilsConfig extends Config {
 
     @Switch(
         name = "Hide Duels Cosmetics",
+        description = "Hide Duels Cosmetics in Hypixel.",
         category = "Game", subcategory = "Visual"
     )
     public static boolean hideDuelsCosmetics;
 
     @Switch(
         name = "Hide Actionbar in Housing",
+        description = "Hide the Actionbar in Housing.",
         category = "Game", subcategory = "Visual"
     )
     public static boolean hideHousingActionBar;
 
     @Switch(
         name = "Hide Actionbar in Dropper",
+        description = "Hide the Actionbar in Dropper.",
         category = "Game", subcategory = "Visual"
     )
     public static boolean hideDropperActionBar;
 
     @Switch(
         name = "Remove Non-NPCs in SkyBlock",
+        description = "Remove entities that are not NPCs in SkyBlock.",
         category = "Game", subcategory = "Visual"
     )
     public static boolean hideNonNPCs;
 
     @Switch(
         name = "Middle Waypoint Beacon in MiniWalls",
+        description = "Adds a beacon at (0,0) when your MiniWither is dead in MiniWalls.",
         category = "Game", subcategory = "Visual"
     )
     public static boolean miniWallsMiddleBeacon;
@@ -764,12 +851,14 @@ public class HytilsConfig extends Config {
 
     @Switch(
         name = "Mute Housing Music",
+        description = "Prevent the Housing songs from being heard.",
         category = "Game", subcategory = "Sound"
     )
     public static boolean muteHousingMusic;
 
     @Switch(
         name = "Notify When Blocks Run Out",
+        description = "Pings you via a sound when your blocks are running out.",
         category = "Game", subcategory = "Sound"
     )
     public static boolean blockNotify;
@@ -792,24 +881,28 @@ public class HytilsConfig extends Config {
 
     @Switch(
         name = "Hide Lobby NPCs",
+        description = "Hide NPCs in the lobby.",
         category = "Lobby", subcategory = "Entities"
     )
     public static boolean npcHider;
 
     @Switch(
         name = "Hide Useless Lobby Nametags",
+        description = "Hides unnecessary nametags such as those that say \"RIGHT CLICK\" or \"CLICK TO PLAY\" in a lobby, as well as other useless ones.",
         category = "Lobby", subcategory = "Entities"
     )
     public static boolean hideUselessArmorStands;
 
     @Switch(
         name = "Remove Limbo AFK Title",
+        description = "Remove the AFK title when you get sent to limbo for being AFK.",
         category = "Lobby", subcategory = "General"
     )
     public static boolean hideLimboTitle;
 
     @Switch(
         name = "Limbo Limiter",
+        description = "While in Limbo, limit your framerate to reduce the load of the game on your computer.",
         category = "Lobby", subcategory = "General"
     )
     public static boolean limboLimiter;
@@ -823,18 +916,21 @@ public class HytilsConfig extends Config {
 
     @Switch(
         name = "Limbo PM Ding",
+        description = "While in Limbo, play the ding sound if you get a PM. Currently, Hypixel's option does not work in Limbo.",
         category = "Lobby", subcategory = "General"
     )
     public static boolean limboDing;
 
     @Switch(
         name = "Hide Lobby Bossbars",
+        description = "Hide the bossbar in the lobby.",
         category = "Lobby", subcategory = "GUI"
     )
     public static boolean lobbyBossbar;
 
     @Switch(
         name = "Mystery Box Star",
+        description = "Shows what star a mystery box is in the Mystery Box Vault, Orange stars are special boxes.",
         category = "Lobby", subcategory = "GUI"
     )
     public static boolean mysteryBoxStar;

--- a/src/main/java/cc/woverflow/hytils/handlers/chat/modules/triggers/AutoFriend.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/chat/modules/triggers/AutoFriend.java
@@ -43,6 +43,7 @@ public class AutoFriend implements ChatReceiveModule {
             if (name.startsWith("[")) {
                 name = name.substring(name.indexOf("] ") + 2);
             }
+            HytilsReborn.INSTANCE.getCommandQueue().queue("/friend " + name);
             Notifications.INSTANCE.send(HytilsReborn.MOD_NAME, "Automatically added " + name + " to your friend list.");
         }
     }

--- a/src/main/java/cc/woverflow/hytils/handlers/chat/modules/triggers/AutoFriend.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/chat/modules/triggers/AutoFriend.java
@@ -18,10 +18,10 @@
 
 package cc.woverflow.hytils.handlers.chat.modules.triggers;
 
+import cc.polyfrost.oneconfig.utils.Notifications;
 import cc.woverflow.hytils.HytilsReborn;
 import cc.woverflow.hytils.config.HytilsConfig;
 import cc.woverflow.hytils.handlers.chat.ChatReceiveModule;
-import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import org.jetbrains.annotations.NotNull;
 
@@ -43,8 +43,7 @@ public class AutoFriend implements ChatReceiveModule {
             if (name.startsWith("[")) {
                 name = name.substring(name.indexOf("] ") + 2);
             }
-            HytilsReborn.INSTANCE.getCommandQueue().queue("/friend " + name);
-            HytilsReborn.INSTANCE.sendMessage(EnumChatFormatting.GREEN + "Automatically added " + name + " to your friend list.");
+            Notifications.INSTANCE.send(HytilsReborn.MOD_NAME, "Automatically added " + name + " to your friend list.");
         }
     }
 

--- a/src/main/java/cc/woverflow/hytils/hooks/LineSeparatorEnhancements.java
+++ b/src/main/java/cc/woverflow/hytils/hooks/LineSeparatorEnhancements.java
@@ -78,7 +78,7 @@ public class LineSeparatorEnhancements {
                 return cached;
             } else {
                 String unformattedText = EnumChatFormatting.getTextWithoutFormattingCodes(formattedText);
-                if (isUncleanSeparator(unformattedText) || ((unformattedText.startsWith("-") && unformattedText.endsWith("-")) && formattedText.contains("§m"))) {
+                if (isUncleanSeparator(unformattedText) || ((unformattedText.startsWith("-") && unformattedText.endsWith("-")) && !formattedText.contains("§m"))) {
                     String processedText = Minecraft.getMinecraft().fontRendererObj.trimStringToWidth(formattedText.replace("▬▬", "§m--").replace("≡≡", "§m--").replace("--", "§m--"), Minecraft.getMinecraft().ingameGUI.getChatGUI().getChatWidth() + 6);
                     cache.put(formattedText, processedText);
                     return processedText;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- Re-added descriptions to the config and refractor the Readme to match the correct order.
- Fixed Clean Line Separators didn't work with some messages.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None

## How to test
<!-- Provide steps to test this PR -->
Open the Hytils GUI and see if it works.
Claim your daily Delivery Man reward and check if the separators are cleaned.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Re-added descriptions to the config
Fixed Clean Line Separators didn't work with some messages
```