### PR TITLE
fix null pointer exception in BedLocationHandler

### DIFF
--- a/src/main/java/cc/woverflow/hytils/handlers/cache/BedLocationHandler.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/cache/BedLocationHandler.java
@@ -32,6 +32,7 @@ import com.google.gson.JsonPrimitive;
 import net.minecraft.client.Minecraft;
 
 import java.util.HashMap;
+import java.util.Objects;
 
 public class BedLocationHandler {
     public static final BedLocationHandler INSTANCE = new BedLocationHandler();
@@ -130,7 +131,7 @@ public class BedLocationHandler {
         }
 
         String serverId = event.info.getServerId();
-        if (lastServer.equals(serverId)) {
+        if (Objects.equals(lastServer, serverId)) {
             return;
         }
         lastServer = serverId;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
fixes the null pointer exeption when joining a bedwars map

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None

## How to test
<!-- Provide steps to test this PR -->
join a bedwars game and check your log

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
fixed null pointer exeption when joining a bedwars map
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->