### PR TITLE
fix: resolve Clean Line Separators not working when chat is fading

### DIFF
--- a/src/main/java/cc/woverflow/hytils/hooks/LineSeparatorEnhancements.java
+++ b/src/main/java/cc/woverflow/hytils/hooks/LineSeparatorEnhancements.java
@@ -78,8 +78,8 @@ public class LineSeparatorEnhancements {
                 return cached;
             } else {
                 String unformattedText = EnumChatFormatting.getTextWithoutFormattingCodes(formattedText);
-                if (isUncleanSeparator(unformattedText) || ((unformattedText.startsWith("-") && unformattedText.endsWith("-")) && !formattedText.contains("§m"))) {
-                    String processedText = Minecraft.getMinecraft().fontRendererObj.trimStringToWidth(formattedText.replace("▬▬", "§m--").replace("≡≡", "§m--").replace("--", "§m--"), Minecraft.getMinecraft().ingameGUI.getChatGUI().getChatWidth() + 6);
+                if (isSeparator(unformattedText)) {
+                    String processedText = Minecraft.getMinecraft().fontRendererObj.trimStringToWidth(formattedText.replace("▬", "§m  ").replace("≡", "§m  ").replace("-", "§m  "), Minecraft.getMinecraft().ingameGUI.getChatGUI().getChatWidth() + 6);
                     cache.put(formattedText, processedText);
                     return processedText;
                 }
@@ -90,9 +90,5 @@ public class LineSeparatorEnhancements {
 
     public static boolean isSeparator(String s) {
         return (s.startsWith("-") && s.endsWith("-")) || (s.startsWith("▬") && s.endsWith("▬")) || (s.startsWith("≡") && s.endsWith("≡"));
-    }
-
-    public static boolean isUncleanSeparator(String s) {
-        return (s.startsWith("▬") && s.endsWith("▬")) || (s.startsWith("≡") && s.endsWith("≡"));
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
replaced strikethrough "--" characters with strikethrough whitespaces

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None

## How to test
<!-- Provide steps to test this PR -->
get a message that has a line separator, e.g. when a game ends and watch if it breaks when chat is fading

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
fixed Clean Line Separators not working when chat is fading
```