### PR TITLE
fix: resolve offline Mojang API crashing the game and fixed ads in tab not being correctly toggleable

### DIFF
--- a/src/main/java/cc/woverflow/hytils/handlers/game/titles/CountdownTitles.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/game/titles/CountdownTitles.java
@@ -32,7 +32,7 @@ public class CountdownTitles {
             return;
         }
 
-        switch (EnumChatFormatting.getTextWithoutFormattingCodes(event.getTitle())) {
+        switch (EnumChatFormatting.getTextWithoutFormattingCodes(event.getTitle().toUpperCase())) {
             case "60":
             case "30":
             case "10":

--- a/src/main/java/cc/woverflow/hytils/handlers/lobby/armorstands/ArmorStandHider.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/lobby/armorstands/ArmorStandHider.java
@@ -33,7 +33,7 @@ public class ArmorStandHider {
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onEntityRenderer(RenderLivingEvent.Pre<EntityLivingBase> event) {
         final LocrawInfo locraw = LocrawUtil.INSTANCE.getLocrawInfo();
-        if (HypixelUtils.INSTANCE.isHypixel() && locraw != null && ((!LocrawUtil.INSTANCE.isInGame() && HytilsConfig.hideUselessArmorStands) || (HytilsConfig.hideUselessArmorStandsGame && LocrawUtil.INSTANCE.isInGame() && (locraw.getGameType() == LocrawInfo.GameType.SKYBLOCK || locraw.getGameType() == LocrawInfo.GameType.BEDWARS || locraw.getGameType() == LocrawInfo.GameType.SKYWARS || locraw.getGameMode().contains("BRIDGE"))))) {
+        if (HypixelUtils.INSTANCE.isHypixel() && ((!LocrawUtil.INSTANCE.isInGame() && HytilsConfig.hideUselessArmorStands) || (HytilsConfig.hideUselessArmorStandsGame && LocrawUtil.INSTANCE.isInGame() && locraw != null && (locraw.getGameType() == LocrawInfo.GameType.SKYBLOCK || locraw.getGameType() == LocrawInfo.GameType.BEDWARS || locraw.getGameType() == LocrawInfo.GameType.SKYWARS || locraw.getGameMode().contains("BRIDGE"))))) {
             if (event.entity instanceof EntityArmorStand) {
                 String unformattedArmorStandName = event.entity.getCustomNameTag().toLowerCase();
                 for (String armorStands : ArmorStandHandler.INSTANCE.armorStandNames) {

--- a/src/main/java/cc/woverflow/hytils/handlers/lobby/tab/TabChanger.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/lobby/tab/TabChanger.java
@@ -25,14 +25,10 @@ import cc.woverflow.hytils.HytilsReborn;
 import cc.woverflow.hytils.config.HytilsConfig;
 import cc.woverflow.hytils.handlers.language.LanguageData;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.network.NetworkPlayerInfo;
-import net.minecraft.util.ChatComponentText;
-import net.minecraft.util.IChatComponent;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.regex.Pattern;
 
 /**
@@ -127,36 +123,36 @@ public class TabChanger {
         return name;
     }
 
-    public static IChatComponent modifyFooter(IChatComponent footer) {
-        if (HytilsConfig.hideAdsInTab && HypixelUtils.INSTANCE.isHypixel() && footer != null && footer.getFormattedText().contains(language.tabFooterAdvertisement)) {
-            String trimmedFooter = footer.getFormattedText().replaceAll((trimChatComponentTextRegex.pattern()), "");
+    public static List<String> modifyFooter(FontRenderer instance, String formattedFooter, int wrapWidth) {
+        if (HytilsConfig.hideAdsInTab && HypixelUtils.INSTANCE.isHypixel() && formattedFooter.contains(language.tabFooterAdvertisement)) {
+            String trimmedFooter = formattedFooter.replaceAll((trimChatComponentTextRegex.pattern()), "");
             if (trimmedFooter.matches(language.tabFooterAdvertisement)) {
-                footer = null;
+                return new ArrayList<>();
             } else {
                 for (String line : new ArrayList<>(Arrays.asList(trimmedFooter.split("\n")))) {
                     if (line.contains(language.tabFooterAdvertisement)) {
-                        footer = new ChatComponentText(footer.getFormattedText().replace(line, "").replaceAll(("^|(?:\\s|§r|§s)*$"), ""));
+                        formattedFooter = formattedFooter.replace(line, "").replaceAll(("^|(?:\\s|§r|§s)*$"), "");
                     }
                 }
             }
         }
-        return footer;
+        return instance.listFormattedStringToWidth(formattedFooter, wrapWidth - 50);
     }
 
-    public static IChatComponent modifyHeader(IChatComponent header) {
-        if (HytilsConfig.hideAdsInTab && HypixelUtils.INSTANCE.isHypixel() && header != null && header.getFormattedText().contains(language.tabHeaderAdvertisement)) {
-            String trimmedHeader = header.getFormattedText().replaceAll((trimChatComponentTextRegex.pattern()), "");
+    public static List<String> modifyHeader(FontRenderer instance, String formattedHeader, int wrapWidth) {
+        if (HytilsConfig.hideAdsInTab && HypixelUtils.INSTANCE.isHypixel() && formattedHeader.contains(language.tabHeaderAdvertisement)) {
+            String trimmedHeader = formattedHeader.replaceAll((trimChatComponentTextRegex.pattern()), "");
             if (trimmedHeader.matches(language.tabHeaderAdvertisement)) {
-                header = null;
+                return new ArrayList<>();
             } else {
                 for (String line : new ArrayList<>(Arrays.asList(trimmedHeader.split("\n")))) {
                     if (line.contains(language.tabHeaderAdvertisement)) {
-                        header = new ChatComponentText(header.getFormattedText().replace(line, "").replaceAll(("^(?:\\s|§r|§s)*|$"), ""));
+                        formattedHeader = formattedHeader.replace(line, "").replaceAll(("^(?:\\s|§r|§s)*|$"), "");
                     }
                 }
             }
         }
-        return header;
+        return instance.listFormattedStringToWidth(formattedHeader, wrapWidth - 50);
     }
 
     public static boolean shouldRenderPlayerHead(NetworkPlayerInfo networkPlayerInfo) {

--- a/src/main/java/cc/woverflow/hytils/handlers/render/ChestHighlighter.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/render/ChestHighlighter.java
@@ -22,6 +22,7 @@ import cc.polyfrost.oneconfig.config.core.OneColor;
 import cc.polyfrost.oneconfig.utils.hypixel.LocrawInfo;
 import cc.polyfrost.oneconfig.utils.hypixel.LocrawUtil;
 import cc.woverflow.hytils.config.HytilsConfig;
+import cc.woverflow.hytils.events.TitleEvent;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
@@ -32,6 +33,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityChest;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.BlockPos;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.world.WorldEvent;
@@ -62,6 +64,13 @@ public class ChestHighlighter {
     @SubscribeEvent
     public void onWorldChange(WorldEvent.Unload event) {
         highlightedChestPositions.clear();
+    }
+
+    @SubscribeEvent
+    public void onTitle(TitleEvent event) {
+        if (EnumChatFormatting.getTextWithoutFormattingCodes(event.getSubtitle()).equals("All chests have been refilled!")) {
+            highlightedChestPositions.clear();
+        }
     }
 
     @SubscribeEvent
@@ -96,6 +105,7 @@ public class ChestHighlighter {
     /**
      * Taken from NotEnoughUpdates under Creative Commons Attribution-NonCommercial 3.0
      * https://github.com/Moulberry/NotEnoughUpdates/blob/master/LICENSE
+     *
      * @author Moulberry
      */
     private void drawFilledBoundingBox(AxisAlignedBB aabb, OneColor c) {
@@ -107,7 +117,7 @@ public class ChestHighlighter {
         Tessellator tessellator = Tessellator.getInstance();
         WorldRenderer worldrenderer = tessellator.getWorldRenderer();
 
-        GlStateManager.color(c.getRed()/255f, c.getGreen()/255f, c.getBlue()/255f, c.getAlpha()/255f* (float) 0.8);
+        GlStateManager.color(c.getRed() / 255f, c.getGreen() / 255f, c.getBlue() / 255f, c.getAlpha() / 255f * (float) 0.8);
 
         //vertical
         worldrenderer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION);
@@ -124,7 +134,7 @@ public class ChestHighlighter {
         tessellator.draw();
 
 
-        GlStateManager.color(c.getRed()/255f*0.8f, c.getGreen()/255f*0.8f, c.getBlue()/255f*0.8f, c.getAlpha()/255f* (float) 0.8);
+        GlStateManager.color(c.getRed() / 255f * 0.8f, c.getGreen() / 255f * 0.8f, c.getBlue() / 255f * 0.8f, c.getAlpha() / 255f * (float) 0.8);
 
         //x
         worldrenderer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION);
@@ -141,7 +151,7 @@ public class ChestHighlighter {
         tessellator.draw();
 
 
-        GlStateManager.color(c.getRed()/255f*0.9f, c.getGreen()/255f*0.9f, c.getBlue()/255f*0.9f, c.getAlpha()/255f* (float) 0.8);
+        GlStateManager.color(c.getRed() / 255f * 0.9f, c.getGreen() / 255f * 0.9f, c.getBlue() / 255f * 0.9f, c.getAlpha() / 255f * (float) 0.8);
         //z
         worldrenderer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION);
         worldrenderer.pos(aabb.minX, aabb.maxY, aabb.minZ).endVertex();

--- a/src/main/java/cc/woverflow/hytils/mixin/GuiIngameForgeMixin_HideHotbar.java
+++ b/src/main/java/cc/woverflow/hytils/mixin/GuiIngameForgeMixin_HideHotbar.java
@@ -34,14 +34,14 @@ public class GuiIngameForgeMixin_HideHotbar {
     @Inject(method = "renderHealth", at = @At("HEAD"), cancellable = true)
     public void cancelHealthbar(int width, int height, CallbackInfo ci) {
         LocrawInfo locraw = LocrawUtil.INSTANCE.getLocrawInfo();
-        if (HytilsConfig.hideHudElements && locraw != null && HypixelUtils.INSTANCE.isHypixel()) {
+        if (HytilsConfig.hideHudElements && HypixelUtils.INSTANCE.isHypixel()) {
             if (!LocrawUtil.INSTANCE.isInGame()) {
                 // rudimentary check if player has engaged in pvp or something
                 if (Minecraft.getMinecraft().thePlayer.getHealth() < 20) return;
                 ci.cancel();
                 return;
             }
-
+            if (locraw == null) return;
             LocrawInfo.GameType gameType = locraw.getGameType();
             String gameMode = locraw.getGameMode();
             switch (gameType) {
@@ -82,12 +82,12 @@ public class GuiIngameForgeMixin_HideHotbar {
     @Inject(method = "renderFood", at = @At("HEAD"), cancellable = true)
     public void cancelFood(int width, int height, CallbackInfo ci) {
         LocrawInfo locraw = LocrawUtil.INSTANCE.getLocrawInfo();
-        if (HytilsConfig.hideHudElements && locraw != null && HypixelUtils.INSTANCE.isHypixel()) {
+        if (HytilsConfig.hideHudElements && HypixelUtils.INSTANCE.isHypixel()) {
             if (!LocrawUtil.INSTANCE.isInGame()) {
                 ci.cancel();
                 return;
             }
-
+            if (locraw == null) return;
             LocrawInfo.GameType gameType = locraw.getGameType();
             String gameMode = locraw.getGameMode();
             switch (gameType) {
@@ -137,12 +137,12 @@ public class GuiIngameForgeMixin_HideHotbar {
     @Inject(method = "renderArmor", at = @At("HEAD"), cancellable = true)
     public void cancelArmor(int width, int height, CallbackInfo ci) {
         LocrawInfo locraw = LocrawUtil.INSTANCE.getLocrawInfo();
-        if (HytilsConfig.hideHudElements && locraw != null && HypixelUtils.INSTANCE.isHypixel()) {
+        if (HytilsConfig.hideHudElements && HypixelUtils.INSTANCE.isHypixel()) {
             if (!LocrawUtil.INSTANCE.isInGame()) {
                 ci.cancel();
                 return;
             }
-
+            if (locraw == null) return;
             LocrawInfo.GameType gameType = locraw.getGameType();
             String gameMode = locraw.getGameMode();
             switch (gameType) {
@@ -175,12 +175,12 @@ public class GuiIngameForgeMixin_HideHotbar {
     @Inject(method = "renderAir", at = @At("HEAD"), cancellable = true)
     public void cancelAir(int width, int height, CallbackInfo ci) {
         LocrawInfo locraw = LocrawUtil.INSTANCE.getLocrawInfo();
-        if (HytilsConfig.hideHudElements && locraw != null && HypixelUtils.INSTANCE.isHypixel()) {
+        if (HytilsConfig.hideHudElements && HypixelUtils.INSTANCE.isHypixel()) {
             if (!LocrawUtil.INSTANCE.isInGame()) {
                 ci.cancel();
                 return;
             }
-
+            if (locraw == null) return;
             LocrawInfo.GameType gameType = locraw.getGameType();
             switch (gameType) {
                 case BUILD_BATTLE:

--- a/src/main/java/cc/woverflow/hytils/mixin/GuiPlayerTabOverlayMixin_RemoveAds.java
+++ b/src/main/java/cc/woverflow/hytils/mixin/GuiPlayerTabOverlayMixin_RemoveAds.java
@@ -19,28 +19,26 @@
 package cc.woverflow.hytils.mixin;
 
 import cc.woverflow.hytils.handlers.lobby.tab.TabChanger;
+import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiPlayerTabOverlay;
-import net.minecraft.scoreboard.ScoreObjective;
-import net.minecraft.scoreboard.Scoreboard;
-import net.minecraft.util.IChatComponent;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.List;
 
 @Mixin(GuiPlayerTabOverlay.class)
 public class GuiPlayerTabOverlayMixin_RemoveAds {
 
-    @Shadow
-    private IChatComponent footer;
+    @Redirect(method = "renderPlayerlist", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/FontRenderer;listFormattedStringToWidth(Ljava/lang/String;I)Ljava/util/List;", ordinal = 1))
+    private List<String> hideAdvertisementsInTabFooter(FontRenderer instance, String formattedFooter, int wrapWidth) {
+        return TabChanger.modifyFooter(instance, formattedFooter, wrapWidth);
 
-    @Shadow
-    private IChatComponent header;
+    }
 
-    @Inject(method = "renderPlayerlist", at = @At("HEAD"))
-    private void hideAdvertisementsInTab(int width, Scoreboard scoreboard, ScoreObjective objective, CallbackInfo ci) {
-        footer = TabChanger.modifyFooter(footer);
-        header = TabChanger.modifyHeader(header);
+    @Redirect(method = "renderPlayerlist", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/FontRenderer;listFormattedStringToWidth(Ljava/lang/String;I)Ljava/util/List;", ordinal = 0))
+    private List<String> hideAdvertisementsInTabHeader(FontRenderer instance, String formattedHeader, int wrapWidth) {
+        return TabChanger.modifyHeader(instance, formattedHeader, wrapWidth);
+
     }
 }

--- a/src/main/java/cc/woverflow/hytils/util/HypixelAPIUtils.java
+++ b/src/main/java/cc/woverflow/hytils/util/HypixelAPIUtils.java
@@ -292,15 +292,23 @@ public class HypixelAPIUtils {
      * @param username The username of the player to get.
      */
     public static String getUUID(String username) {
-        JsonObject uuidResponse =
-            NetworkUtils.getJsonElement("https://api.mojang.com/users/profiles/minecraft/" + username).getAsJsonObject();
-        if (uuidResponse.has("error")) {
+        try {
+            JsonObject uuidResponse =
+                NetworkUtils.getJsonElement("https://api.mojang.com/users/profiles/minecraft/" + username).getAsJsonObject();
+            if (uuidResponse.has("error")) {
+                HytilsReborn.INSTANCE.sendMessage(
+                    EnumChatFormatting.RED + "Failed with error: " + uuidResponse.get("reason").getAsString()
+                );
+                return null;
+            }
+            return uuidResponse.get("id").getAsString();
+        } catch (Exception e) {
+            e.printStackTrace();
             HytilsReborn.INSTANCE.sendMessage(
-                EnumChatFormatting.RED + "Failed with error: " + uuidResponse.get("reason").getAsString()
+                EnumChatFormatting.RED + "The Mojang API is currently down. Please try again later."
             );
             return null;
         }
-        return uuidResponse.get("id").getAsString();
     }
 
     public static boolean isValidKey(String key) {


### PR DESCRIPTION

## Description
<!-- Describe your changes in detail -->
fixed offline Mojang API crashing the game
fixed ads in tab not being correctly toggleable
reset chest highlightener when chests have been refilled

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
fixed offline Mojang API crashing the game
fixed ads in tab not being correctly toggleable
reset chest highlightener when chests have been refilled
```