### PR TITLE
new: hide dropper hurt sounds

### DIFF
--- a/src/main/java/cc/woverflow/hytils/HytilsReborn.java
+++ b/src/main/java/cc/woverflow/hytils/HytilsReborn.java
@@ -31,6 +31,7 @@ import cc.woverflow.hytils.handlers.chat.modules.events.AchievementEvent;
 import cc.woverflow.hytils.handlers.chat.modules.events.LevelupEvent;
 import cc.woverflow.hytils.handlers.chat.modules.triggers.AutoQueue;
 import cc.woverflow.hytils.handlers.chat.modules.triggers.SilentRemoval;
+import cc.woverflow.hytils.handlers.game.dropper.DropperHurtSound;
 import cc.woverflow.hytils.handlers.game.duels.SumoRenderDistance;
 import cc.woverflow.hytils.handlers.game.hardcore.HardcoreStatus;
 import cc.woverflow.hytils.handlers.game.housing.HousingMusic;
@@ -182,6 +183,7 @@ public class HytilsReborn {
         eventBus.register(new SumoRenderDistance());
         eventBus.register(new MiddleBeaconMiniWalls());
         eventBus.register(new MiddleWaypointUHC());
+        eventBus.register(new DropperHurtSound());
 
         // height overlay
         EventManager.INSTANCE.register(HeightHandler.INSTANCE);

--- a/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
+++ b/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
@@ -884,7 +884,7 @@ public class HytilsConfig extends Config {
 
     @Switch(
         name = "Mute Hurt Sounds in Dropper",
-        description = "Mute the sounds of other player's failing in Dropper.",
+        description = "Mute the sounds of other players failing in Dropper.",
         category = "Game", subcategory = "Dropper"
     )
     public static boolean muteDropperHurtSound;

--- a/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
+++ b/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
@@ -883,6 +883,13 @@ public class HytilsConfig extends Config {
     public static boolean hideDropperActionBar;
 
     @Switch(
+        name = "Mute Hurt Sounds in Dropper",
+        description = "Hide the sounds of other player's failing in Dropper.",
+        category = "Game", subcategory = "Dropper"
+    )
+    public static boolean muteDropperHurtSound;
+
+    @Switch(
         name = "Lower Render Distance in Sumo",
         description = "Lowers render distance to your desired value in Sumo Duels.",
         category = "Game", subcategory = "Duels"

--- a/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
+++ b/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
@@ -884,7 +884,7 @@ public class HytilsConfig extends Config {
 
     @Switch(
         name = "Mute Hurt Sounds in Dropper",
-        description = "Hide the sounds of other player's failing in Dropper.",
+        description = "Mute the sounds of other player's failing in Dropper.",
         category = "Game", subcategory = "Dropper"
     )
     public static boolean muteDropperHurtSound;

--- a/src/main/java/cc/woverflow/hytils/handlers/game/dropper/DropperHurtSound.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/game/dropper/DropperHurtSound.java
@@ -1,0 +1,37 @@
+/*
+ * Hytils Reborn - Hypixel focused Quality of Life mod.
+ * Copyright (C) 2020, 2021, 2022, 2023  Polyfrost, Sk1er LLC and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package cc.woverflow.hytils.handlers.game.dropper;
+
+import cc.polyfrost.oneconfig.utils.hypixel.HypixelUtils;
+import cc.polyfrost.oneconfig.utils.hypixel.LocrawInfo;
+import cc.polyfrost.oneconfig.utils.hypixel.LocrawUtil;
+import cc.woverflow.hytils.config.HytilsConfig;
+import net.minecraftforge.client.event.sound.PlaySoundEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+public class DropperHurtSound {
+
+    @SubscribeEvent
+    public void onSound(PlaySoundEvent event) {
+        LocrawInfo locraw = LocrawUtil.INSTANCE.getLocrawInfo();
+        if (HytilsConfig.muteDropperHurtSound && HypixelUtils.INSTANCE.isHypixel() && locraw != null && locraw.getGameMode().equalsIgnoreCase("dropper") && event.name.equals("game.player.hurt")) {
+            event.result = null;
+        }
+    }
+}


### PR DESCRIPTION
## Description
For some reason in Dropper you can hear the sounds of other people failing when you're at the top. This is stupid. You can still hear your own fall damage step sound.

## Related Issue(s)
N/A

## How to test
Play dropper

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
+ Hide other the sounds of other people failing in dropper.
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->