### PR TITLE
new: discord safety warning remover

### DIFF
--- a/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
+++ b/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
@@ -555,7 +555,7 @@ public class HytilsConfig extends Config {
 
     @Switch(
         name = "Remove Discord Safety Warning Messages",
-        description = "Removes \"§4Please be mindful of Discord link in chat as they may pose a security risk\"",
+        description = "Removes \"§4Please be mindful of Discord links in chat as they may pose a security risk\"",
         category = "Chat", subcategory = "Toggles"
     )
     public static boolean discordSafetyWarning;

--- a/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
+++ b/src/main/java/cc/woverflow/hytils/config/HytilsConfig.java
@@ -553,6 +553,13 @@ public class HytilsConfig extends Config {
     )
     public static boolean hotPotato;
 
+    @Switch(
+        name = "Remove Discord Safety Warning Messages",
+        description = "Removes \"§4Please be mindful of Discord link in chat as they may pose a security risk\"",
+        category = "Chat", subcategory = "Toggles"
+    )
+    public static boolean discordSafetyWarning;
+
     // AutoWB
 
     @Switch(

--- a/src/main/java/cc/woverflow/hytils/handlers/chat/ChatHandler.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/chat/ChatHandler.java
@@ -56,6 +56,7 @@ public class ChatHandler {
         this.registerModule(new ConnectedMessage());
         this.registerModule(new ConnectionStatusRemover());
         this.registerModule(new CurseOfSpamRemover());
+        this.registerModule(new DiscordSafetyWarningRemover());
         this.registerModule(new DuelsBlockTrail());
         this.registerModule(new DuelsNoStatsChange());
         this.registerModule(new EarnedCoinsAndExpRemover());

--- a/src/main/java/cc/woverflow/hytils/handlers/chat/modules/blockers/DiscordSafetyWarningRemover.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/chat/modules/blockers/DiscordSafetyWarningRemover.java
@@ -1,0 +1,45 @@
+/*
+ * Hytils Reborn - Hypixel focused Quality of Life mod.
+ * Copyright (C) 2020, 2021, 2022, 2023  Polyfrost, Sk1er LLC and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package cc.woverflow.hytils.handlers.chat.modules.blockers;
+
+import cc.woverflow.hytils.config.HytilsConfig;
+import cc.woverflow.hytils.handlers.chat.ChatReceiveModule;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraftforge.client.event.ClientChatReceivedEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class DiscordSafetyWarningRemover implements ChatReceiveModule {
+    @Override
+    public void onMessageReceived(@NotNull ClientChatReceivedEvent event) {
+        String message = EnumChatFormatting.getTextWithoutFormattingCodes(event.message.getUnformattedText());
+        if (message.equals(getLanguage().chatDiscordSafetyWarning)) {
+            event.setCanceled(true);
+        }
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return HytilsConfig.discordSafetyWarning;
+    }
+
+    @Override
+    public int getPriority() {
+        return -1;
+    }
+}

--- a/src/main/java/cc/woverflow/hytils/handlers/language/LanguageData.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/language/LanguageData.java
@@ -62,6 +62,7 @@ public class LanguageData {
     public String chatCleanerCurseOfSpam = "KALI HAS STRIKEN YOU WITH THE CURSE OF SPAM";
     public String chatCleanerDuelsBlockTrail = "Your block trail aura is disabled in this mode!";
     public String chatCleanerSkyblockWelcome = "Welcome to Hypixel SkyBlock!";
+    public String chatDiscordSafetyWarning = "Please be mindful of Discord link in chat as they may pose a security risk";
 
     private String achievementPattern = "a>> {3}Achievement Unlocked: (?<achievement>.+) {3}<<a";
     private String levelUpPattern = "You are now Hypixel Level (?<level>\\d+)!";

--- a/src/main/java/cc/woverflow/hytils/handlers/language/LanguageData.java
+++ b/src/main/java/cc/woverflow/hytils/handlers/language/LanguageData.java
@@ -62,7 +62,7 @@ public class LanguageData {
     public String chatCleanerCurseOfSpam = "KALI HAS STRIKEN YOU WITH THE CURSE OF SPAM";
     public String chatCleanerDuelsBlockTrail = "Your block trail aura is disabled in this mode!";
     public String chatCleanerSkyblockWelcome = "Welcome to Hypixel SkyBlock!";
-    public String chatDiscordSafetyWarning = "Please be mindful of Discord link in chat as they may pose a security risk";
+    public String chatDiscordSafetyWarning = "Please be mindful of Discord links in chat as they may pose a security risk";
 
     private String achievementPattern = "a>> {3}Achievement Unlocked: (?<achievement>.+) {3}<<a";
     private String levelUpPattern = "You are now Hypixel Level (?<level>\\d+)!";


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
relating datastorage pr https://github.com/Polyfrost/DataStorage/pull/50

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Remove discord safety warning feature when discord is sent in chat
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->