### PR TITLE
add auto afk reply

### DIFF
--- a/src/main/java/org/polyfrost/hytils/config/HytilsConfig.java
+++ b/src/main/java/org/polyfrost/hytils/config/HytilsConfig.java
@@ -172,6 +172,13 @@ public class HytilsConfig extends Config {
     public static boolean autoPartyWarpConfirm;
 
     @Switch(
+        name = "Auto Reply When AFK",
+        description = "Automatically sends a reply to anyone who PMs you when you are AFK in Limbo.",
+        category = "Chat", subcategory = "Automatic"
+    )
+    public static boolean autoReplyAfk;
+
+    @Switch(
         name = "Game Status Restyle",
         description = "Replace common game status messages with a new style.\n§eExamples:\n§a§l+ §bSteve §e(§b1§e/§b12§e)\n§c§l- §bSteve§r\n§e§l* §aGame starts in §b§l5 §aseconds.",
         category = "Chat", subcategory = "Restyler"

--- a/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoAfkReply.java
+++ b/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoAfkReply.java
@@ -18,31 +18,33 @@
 
 package org.polyfrost.hytils.handlers.chat.modules.triggers;
 
-import cc.polyfrost.oneconfig.utils.Multithreading;
-import org.polyfrost.hytils.config.HytilsConfig;
-import org.polyfrost.hytils.handlers.chat.ChatReceiveModule;
-import net.minecraft.client.Minecraft;
+import cc.polyfrost.oneconfig.libs.universal.UChat;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import org.jetbrains.annotations.NotNull;
+import org.polyfrost.hytils.config.HytilsConfig;
+import org.polyfrost.hytils.handlers.chat.ChatReceiveModule;
 
-import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
 
-public class AutoChatReportConfirm implements ChatReceiveModule {
+public class AutoAfkReply implements ChatReceiveModule {
+    // TODO: maybe write a general afk checker for skyblock afkers, as they won't be in limbo
     @Override
     public void onMessageReceived(@NotNull ClientChatReceivedEvent event) {
-        if (event.message.getUnformattedText().equals(getLanguage().autoChatReportConfirm)) {
-            event.setCanceled(true);
-            Multithreading.schedule(() -> Minecraft.getMinecraft().thePlayer.sendChatMessage("/report confirm"), 1, TimeUnit.SECONDS);
+        if (getLocraw() != null && !getLocraw().getServerId().equals("limbo")) return;
+        String message = event.message.getUnformattedText();
+        Matcher matcher = getLanguage().autoAfkReplyPatternRegex.matcher(message);
+        if (matcher.matches()) {
+            UChat.say("/msg " + matcher.group(2) + " Hey "  + matcher.group(2) + ", I am currently AFK!");
         }
     }
 
     @Override
     public boolean isEnabled() {
-        return HytilsConfig.autoChatReportConfirm;
+        return HytilsConfig.autoReplyAfk;
     }
 
     @Override
     public int getPriority() {
-        return 3;
+        return -1;
     }
 }

--- a/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoChatSwapper.java
+++ b/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoChatSwapper.java
@@ -40,12 +40,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 
 public class AutoChatSwapper implements ChatReceiveModule {
-
-    @Override
-    public int getPriority() {
-        return 3;
-    }
-
     @SuppressWarnings("all")
     @Override
     public void onMessageReceived(@NotNull ClientChatReceivedEvent event) {
@@ -116,6 +110,11 @@ public class AutoChatSwapper implements ChatReceiveModule {
     @Override
     public boolean isEnabled() {
         return HytilsConfig.chatSwapper;
+    }
+
+    @Override
+    public int getPriority() {
+        return 3;
     }
 
     public static class ChatChannelMessagePreventer {

--- a/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoGL.java
+++ b/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoGL.java
@@ -33,8 +33,12 @@ public class AutoGL implements ChatReceiveModule {
     }
 
     @Override
-    public int getPriority() {
-        return 3;
+    public void onMessageReceived(@NotNull ClientChatReceivedEvent event) {
+        String message = EnumChatFormatting.getTextWithoutFormattingCodes(event.message.getUnformattedText()).trim();
+        if (message.contains(": ")) return;
+        if (message.endsWith("The game starts in 5 seconds!")) {
+            Minecraft.getMinecraft().thePlayer.sendChatMessage("/ac " + getGLMessage());
+        }
     }
 
     @Override
@@ -43,11 +47,7 @@ public class AutoGL implements ChatReceiveModule {
     }
 
     @Override
-    public void onMessageReceived(@NotNull ClientChatReceivedEvent event) {
-        String message = EnumChatFormatting.getTextWithoutFormattingCodes(event.message.getUnformattedText()).trim();
-        if (message.contains(": ")) return;
-        if (message.endsWith("The game starts in 5 seconds!")) {
-            Minecraft.getMinecraft().thePlayer.sendChatMessage("/ac " + getGLMessage());
-        }
+    public int getPriority() {
+        return 3;
     }
 }

--- a/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoPartyWarpConfirm.java
+++ b/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoPartyWarpConfirm.java
@@ -29,7 +29,6 @@ import org.jetbrains.annotations.NotNull;
 import java.util.concurrent.TimeUnit;
 
 public class AutoPartyWarpConfirm implements ChatReceiveModule {
-
     @Override
     public void onMessageReceived(@NotNull ClientChatReceivedEvent event) {
         final String message = EnumChatFormatting.getTextWithoutFormattingCodes(event.message.getUnformattedText());
@@ -40,12 +39,12 @@ public class AutoPartyWarpConfirm implements ChatReceiveModule {
     }
 
     @Override
-    public int getPriority() {
-        return 3;
+    public boolean isEnabled() {
+        return HytilsConfig.autoPartyWarpConfirm;
     }
 
     @Override
-    public boolean isEnabled() {
-        return HytilsConfig.autoPartyWarpConfirm;
+    public int getPriority() {
+        return 3;
     }
 }

--- a/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoQueue.java
+++ b/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoQueue.java
@@ -36,14 +36,6 @@ public class AutoQueue implements ChatReceiveModule {
     private String command = null;
     private boolean sentCommand;
 
-    /**
-     * We want this to activate early so that it catches the queue message.
-     */
-    @Override
-    public int getPriority() {
-        return -11;
-    }
-
     @Override
     public void onMessageReceived(@NotNull ClientChatReceivedEvent event) {
         if (!HytilsConfig.autoQueue) {
@@ -60,11 +52,6 @@ public class AutoQueue implements ChatReceiveModule {
             }
             this.command = "/play " + game.toLowerCase();
         }
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return HytilsConfig.autoQueue;
     }
 
     @SubscribeEvent
@@ -98,5 +85,18 @@ public class AutoQueue implements ChatReceiveModule {
             }
 
         }, HytilsConfig.autoQueueDelay, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return HytilsConfig.autoQueue;
+    }
+
+    /**
+     * We want this to activate early so that it catches the queue message.
+     */
+    @Override
+    public int getPriority() {
+        return -11;
     }
 }

--- a/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoVictory.java
+++ b/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoVictory.java
@@ -47,16 +47,6 @@ public class AutoVictory implements ChatReceiveResetModule {
     }
 
     @Override
-    public int getPriority() {
-        return 3;
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return HytilsConfig.autoGetWinstreak || HytilsConfig.autoGetGEXP;
-    }
-
-    @Override
     public void onMessageReceived(@NotNull ClientChatReceivedEvent event) {
         String unformattedText = UTextComponent.Companion.stripFormatting(event.message.getUnformattedText());
         if (PatternHandler.INSTANCE.gameEnd.size() != 0) {
@@ -153,4 +143,15 @@ public class AutoVictory implements ChatReceiveResetModule {
         }
         return false;
     }
+
+    @Override
+    public boolean isEnabled() {
+        return HytilsConfig.autoGetWinstreak || HytilsConfig.autoGetGEXP;
+    }
+
+    @Override
+    public int getPriority() {
+        return 3;
+    }
+
 }

--- a/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoWB.java
+++ b/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoWB.java
@@ -33,17 +33,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 
 public class AutoWB implements ChatReceiveModule {
-
-    @Override
-    public int getPriority() {
-        return -6;
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return HytilsConfig.autoWB;
-    }
-
     @Override
     public void onMessageReceived(@NotNull ClientChatReceivedEvent event) {
         String msg = event.message.getFormattedText().trim();
@@ -94,5 +83,15 @@ public class AutoWB implements ChatReceiveModule {
         } else {
             return newMessage.replace("%player%", name);
         }
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return HytilsConfig.autoWB;
+    }
+
+    @Override
+    public int getPriority() {
+        return -6;
     }
 }

--- a/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoWarn.java
+++ b/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoWarn.java
@@ -27,8 +27,10 @@ import org.jetbrains.annotations.NotNull;
 
 public class AutoWarn implements ChatReceiveModule {
     @Override
-    public int getPriority() {
-        return 3;
+    public void onMessageReceived(@NotNull ClientChatReceivedEvent event) {
+        if (UTextComponent.Companion.stripFormatting(event.message.getUnformattedText()).startsWith("A kick")) {
+            UChat.say(HytilsConfig.putInCaps ? "/pc ---------REQUEUE, I'VE BEEN KICKED!---------" : "/pc ---------I've been kicked, please requeue!---------");
+        }
     }
 
     @Override
@@ -37,9 +39,7 @@ public class AutoWarn implements ChatReceiveModule {
     }
 
     @Override
-    public void onMessageReceived(@NotNull ClientChatReceivedEvent event) {
-        if (UTextComponent.Companion.stripFormatting(event.message.getUnformattedText()).startsWith("A kick")) {
-            UChat.say(HytilsConfig.putInCaps ? "/pc ---------REQUEUE, I'VE BEEN KICKED!---------" : "/pc ---------I've been kicked, please requeue!---------");
-        }
+    public int getPriority() {
+        return 3;
     }
 }

--- a/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/GuildWelcomer.java
+++ b/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/GuildWelcomer.java
@@ -27,12 +27,6 @@ import org.jetbrains.annotations.NotNull;
 import java.util.regex.Matcher;
 
 public class GuildWelcomer implements ChatReceiveModule {
-
-    @Override
-    public int getPriority() {
-        return 1;
-    }
-
     @Override
     public void onMessageReceived(@NotNull ClientChatReceivedEvent event) {
         final String text = event.message.getUnformattedText();
@@ -45,5 +39,10 @@ public class GuildWelcomer implements ChatReceiveModule {
     @Override
     public boolean isEnabled() {
         return HytilsConfig.guildWelcomeMessage;
+    }
+
+    @Override
+    public int getPriority() {
+        return 1;
     }
 }

--- a/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/SilentRemoval.java
+++ b/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/SilentRemoval.java
@@ -30,7 +30,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 
 public class SilentRemoval implements ChatReceiveModule {
-
     private static final Set<String> silentUsers = new HashSet<>();
 
     @Override

--- a/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/ThankWatchdog.java
+++ b/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/ThankWatchdog.java
@@ -25,12 +25,6 @@ import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import org.jetbrains.annotations.NotNull;
 
 public class ThankWatchdog implements ChatReceiveModule {
-
-    @Override
-    public int getPriority() {
-        return 3;
-    }
-
     @Override
     public void onMessageReceived(@NotNull ClientChatReceivedEvent event) {
         if (event.message.getUnformattedText().equals("[WATCHDOG ANNOUNCEMENT]") || event.message.getUnformattedText().startsWith("A player has been removed from your")) {
@@ -41,5 +35,10 @@ public class ThankWatchdog implements ChatReceiveModule {
     @Override
     public boolean isEnabled() {
         return HytilsConfig.thankWatchdog;
+    }
+
+    @Override
+    public int getPriority() {
+        return 3;
     }
 }

--- a/src/main/java/org/polyfrost/hytils/handlers/language/LanguageData.java
+++ b/src/main/java/org/polyfrost/hytils/handlers/language/LanguageData.java
@@ -35,6 +35,7 @@ public class LanguageData {
     private String autoQueuePrefixGlobal = "^(?:You died! .+|YOU DIED! .+|You have been eliminated!|You won! .+|YOU WON! .+)$";
 
     private String autoFriendPattern = "Friend request from (?<name>.+)\\[ACCEPT] - \\[DENY] - \\[IGNORE].*";
+    private String autoAfkReplyPattern = "^From (\\[.+?] )?(.+?): .+$";
 
     private String chatCleanerJoin = "(?:sled into|slid into|joined|spooked into) the lobby";
     private String chatCleanerTicketAnnouncer = "^(?<player>(?!You )\\w{1,16} )has found an? .+$";
@@ -114,6 +115,7 @@ public class LanguageData {
     public Pattern autoQueuePrefixGlobalRegex;
 
     public Pattern autoFriendPatternRegex;
+    public Pattern autoAfkReplyPatternRegex;
 
     public Pattern chatCleanerJoinRegex;
     public Pattern chatCleanerTicketAnnouncerRegex;
@@ -176,6 +178,7 @@ public class LanguageData {
             autoQueuePrefixGlobalRegex = Pattern.compile(autoQueuePrefixGlobal);
 
             autoFriendPatternRegex = Pattern.compile(autoFriendPattern);
+            autoAfkReplyPatternRegex = Pattern.compile(autoAfkReplyPattern);
 
             chatCleanerJoinRegex = Pattern.compile(chatCleanerJoin);
             chatCleanerTicketAnnouncerRegex = Pattern.compile(chatCleanerTicketAnnouncer);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Auto reply with afk message when in limbo. pretty straightforwards.

I also just made the order of the methods consistent between all classes in the trigger package, idk it just annoyed me i can revert if wanted.

Accompanying DataStorage PR: https://github.com/Polyfrost/DataStorage/pull/54

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Was on old list of TODO ideas

## How to test
<!-- Provide steps to test this PR -->
Turn on feature and have someone PM you while in limbo (use /limbo)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Add option to automatically reply to anyone who sends you a PM while in AFK in Limbo letting them know you are AFK
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->