### PR TITLE
Allow the user to set custom AutoGG phrases

### DIFF
--- a/src/main/java/org/polyfrost/hytils/config/HytilsConfig.java
+++ b/src/main/java/org/polyfrost/hytils/config/HytilsConfig.java
@@ -162,13 +162,12 @@ public class HytilsConfig extends Config {
     )
     public static boolean antiGG;
 
-    @Dropdown(
+    @Text(
         name = "Auto GG First Message",
         description = "Choose what message is said on game completion.",
-        category = "Chat", subcategory = "Automatic",
-        options = {"gg", "GG", "gf", "Good Game", "Good Fight", "Good Round! :D"}
+        category = "Chat", subcategory = "Automatic"
     )
-    public static int autoGGMessage = 0;
+    public static String autoGGMessage = "gg";
 
     @Slider(
         name = "Auto GG First Phrase Delay",
@@ -178,13 +177,12 @@ public class HytilsConfig extends Config {
     )
     public static float autoGGFirstPhraseDelay = 1;
 
-    @Dropdown(
+    @Text(
         name = "Auto GG Second Message",
         description = "Send a secondary message sent after the first GG message.",
-        category = "Chat", subcategory = "Automatic",
-        options = {"Have a good day!", "<3", "AutoGG By Hytils Reborn!", "gf", "Good Fight", "Good Round", ":D", "Well played!", "wp"}
+        category = "Chat", subcategory = "Automatic"
     )
-    public static int autoGGMessage2 = 0;
+    public static String autoGGMessage2 = "Have a good day!";
 
     @Slider(
         name = "Auto GG Second Phrase Delay",
@@ -1282,14 +1280,8 @@ public class HytilsConfig extends Config {
                     if (AutoGG.INSTANCE.getAutoGGConfig().isCasualAutoGGEnabled()) {
                         casualAutoGG = true;
                     }
-                    if (AutoGG.INSTANCE.getAutoGGConfig().getAutoGGPhrase() != 0) {
-                        autoGGMessage = AutoGG.INSTANCE.getAutoGGConfig().getAutoGGPhrase();
-                    }
                     if (AutoGG.INSTANCE.getAutoGGConfig().getAutoGGDelay() != 1) {
                         autoGGFirstPhraseDelay = AutoGG.INSTANCE.getAutoGGConfig().getAutoGGDelay();
-                    }
-                    if (AutoGG.INSTANCE.getAutoGGConfig().getAutoGGPhrase2() != 0) {
-                        autoGGMessage2 = AutoGG.INSTANCE.getAutoGGConfig().getAutoGGPhrase2();
                     }
                     if (AutoGG.INSTANCE.getAutoGGConfig().getSecondaryDelay() != 1) {
                         autoGGSecondPhraseDelay = AutoGG.INSTANCE.getAutoGGConfig().getSecondaryDelay();

--- a/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoGG.java
+++ b/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoGG.java
@@ -32,23 +32,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 public class AutoGG implements ChatReceiveModule {
-    private static final String[] ggMessagesOne = {"gg", "GG", "gf", "Good Game", "Good Fight", "Good Round! :D"};
-    private static final String[] ggMessagesTwo = {"Have a good day!", "<3", "AutoGG By Hytils Reborn!", "gf", "Good Fight", "Good Round", ":D", "Well played!", "wp"};
-
-    private static String getGGMessageOne() {
-        return ggMessagesOne[HytilsConfig.autoGGMessage];
-    }
-    private static String getGGMessageTwo() {
-        return ggMessagesTwo[HytilsConfig.autoGGMessage2];
-    }
-
     @Override
     public void onMessageReceived(@NotNull ClientChatReceivedEvent event) {
         String message = EnumChatFormatting.getTextWithoutFormattingCodes(event.message.getUnformattedText());
         if (!hasGameEnded(message)) return;
-        Multithreading.schedule(() -> UChat.say("/ac " + getGGMessageOne()), (long) (HytilsConfig.autoGGFirstPhraseDelay * 1000), TimeUnit.MILLISECONDS);
+        Multithreading.schedule(() -> UChat.say("/ac " + HytilsConfig.autoGGMessage), (long) (HytilsConfig.autoGGFirstPhraseDelay * 1000), TimeUnit.MILLISECONDS);
         if (HytilsConfig.autoGGSecondMessage)
-            Multithreading.schedule(() -> UChat.say("/ac " + getGGMessageTwo()), (long) ((HytilsConfig.autoGGSecondPhraseDelay + HytilsConfig.autoGGFirstPhraseDelay) * 1000), TimeUnit.MILLISECONDS);
+            Multithreading.schedule(() -> UChat.say("/ac " + HytilsConfig.autoGGMessage2), (long) ((HytilsConfig.autoGGSecondPhraseDelay + HytilsConfig.autoGGFirstPhraseDelay) * 1000), TimeUnit.MILLISECONDS);
     }
 
     private boolean hasGameEnded(String message) {


### PR DESCRIPTION
I have a feeling the AutoGG phrases were intentionally limited to prevent toxicity or trolling, but I think the mod would still benefit from allowing that.  The main clients like Lunar and BL have had the otion for a while now so it’s not like you’d be responsible any actions, the cat’s already out of the bag.  Since one of OneConfig’s draws is that it a “better client,” having centralized options and styles while still being customizable, incorporating a highly-used feature like that from clients seems like a good choice to keep it in-line.

But that’s just my belief, it’s your mod so you can keep it limited if you want ofc.  Maybe a compromise could be to have it customizable but have a filter blacklisting common toxic words like “ L “, “better luck”, “ez”, etc.