### PR TITLE
fix(pm): update regex to check for the whole message

### DIFF
--- a/src/main/java/org/polyfrost/hytils/handlers/chat/modules/modifiers/DefaultChatRestyler.java
+++ b/src/main/java/org/polyfrost/hytils/handlers/chat/modules/modifiers/DefaultChatRestyler.java
@@ -209,7 +209,6 @@ public class DefaultChatRestyler implements ChatReceiveModule {
         String originalText = message.getUnformattedTextForChat();
         if (checkParentComponent && !originalText.contains("\u00a7")) {
             originalText = (message.getChatStyle().getFormattingCode() + originalText + EnumChatFormatting.RESET).replaceAll(pattern, replacement);
-            System.out.println(originalText);
         }
         ChatComponentText copy = (ChatComponentText) new ChatComponentText(originalText).setChatStyle(message.getChatStyle());
         for (IChatComponent sibling : message.getSiblings()) {

--- a/src/main/java/org/polyfrost/hytils/handlers/chat/modules/modifiers/DefaultChatRestyler.java
+++ b/src/main/java/org/polyfrost/hytils/handlers/chat/modules/modifiers/DefaultChatRestyler.java
@@ -102,10 +102,10 @@ public class DefaultChatRestyler implements ChatReceiveModule {
             Matcher privateMessageFromMatcher = language.chatRestylerPrivateMessageFromPatternRegex.matcher(message);
             if (privateMessageToMatcher.find()) {
                 event.message = shortenChannelName(event.message, language.chatRestylerPrivateMessageToPatternRegex.pattern(),
-                    "§d" + "PM >", true);
+                    "§d" + "PM >" + privateMessageToMatcher.group(3) + ":" + privateMessageToMatcher.group(4), true);
             } else if (privateMessageFromMatcher.find()) {
                 event.message = shortenChannelName(event.message, language.chatRestylerPrivateMessageFromPatternRegex.pattern(),
-                    "§5" + "PM <", true);
+                    "§5" + "PM <" + privateMessageFromMatcher.group(3) + ":" + privateMessageFromMatcher.group(4), true);
             }
         }
 
@@ -209,6 +209,7 @@ public class DefaultChatRestyler implements ChatReceiveModule {
         String originalText = message.getUnformattedTextForChat();
         if (checkParentComponent && !originalText.contains("\u00a7")) {
             originalText = (message.getChatStyle().getFormattingCode() + originalText + EnumChatFormatting.RESET).replaceAll(pattern, replacement);
+            System.out.println(originalText);
         }
         ChatComponentText copy = (ChatComponentText) new ChatComponentText(originalText).setChatStyle(message.getChatStyle());
         for (IChatComponent sibling : message.getSiblings()) {

--- a/src/main/java/org/polyfrost/hytils/handlers/language/LanguageData.java
+++ b/src/main/java/org/polyfrost/hytils/handlers/language/LanguageData.java
@@ -80,8 +80,8 @@ public class LanguageData {
     private String chatRestylerFriendPattern = "^((?:\u00a7r)?\u00a7\\w)(Friend >)";
     private String chatRestylerOfficerPattern = "^((?:\u00a7r)?\u00a7\\w)(Officer >)";
     private String chatRestylerStatusPattern = "^(?<type>(?:\u00a7aFriend|\u00a7a\u00a7aF|\u00a72Guild|\u00a72\u00a72G)) > (\u00a7r|\u00a7r\u00a7r){1,2}(?<player>\u00a7[\\da-f]\\w{1,16}) \u00a7r\u00a7e(?<status>(?:joined|left))\\.\u00a7r$";
-    private String chatRestylerPrivateMessageToPattern = "^((?:\u00a7r)?\u00a7\\w)(To)";
-    private String chatRestylerPrivateMessageFromPattern = "^((?:\u00a7r)?\u00a7\\w)(From)";
+    private String chatRestylerPrivateMessageToPattern = "^((?:§r)?§\\w)(To)([^:]*):(.*)";
+    private String chatRestylerPrivateMessageFromPattern = "^((?:§r)?§\\w)(From)([^:]*):(.*)";
 
     private String autoChatSwapperPartyStatus = "^(?:You have been kicked from the party by (?:\\[.+] )?\\w{1,16}|(?:\\[.+] )?\\w{1,16} has disbanded the party!|You left the party.)$";
     private String autoChatSwapperPartyStatus2 = "^(?:You have joined (?:\\[.+] )?(?:.*)|Party Members(?:\\[.+] )?\\w{1,100}|(?:\\[.+] )?\\w{1,100} joined the(?:.*) party(?:.*))$";

--- a/src/main/java/org/polyfrost/hytils/handlers/language/LanguageData.java
+++ b/src/main/java/org/polyfrost/hytils/handlers/language/LanguageData.java
@@ -80,8 +80,8 @@ public class LanguageData {
     private String chatRestylerFriendPattern = "^((?:\u00a7r)?\u00a7\\w)(Friend >)";
     private String chatRestylerOfficerPattern = "^((?:\u00a7r)?\u00a7\\w)(Officer >)";
     private String chatRestylerStatusPattern = "^(?<type>(?:\u00a7aFriend|\u00a7a\u00a7aF|\u00a72Guild|\u00a72\u00a72G)) > (\u00a7r|\u00a7r\u00a7r){1,2}(?<player>\u00a7[\\da-f]\\w{1,16}) \u00a7r\u00a7e(?<status>(?:joined|left))\\.\u00a7r$";
-    private String chatRestylerPrivateMessageToPattern = "^((?:§r)?§\\w)(To)([^:]*):(.*)";
-    private String chatRestylerPrivateMessageFromPattern = "^((?:§r)?§\\w)(From)([^:]*):(.*)";
+    private String chatRestylerPrivateMessageToPattern = "^((?:\u00a7r)?\u00a7\\w)(To)([^:]*):(.*)";
+    private String chatRestylerPrivateMessageFromPattern = "^((?:\u00a7r)?\u00a7\\w)(From)([^:]*):(.*)";
 
     private String autoChatSwapperPartyStatus = "^(?:You have been kicked from the party by (?:\\[.+] )?\\w{1,16}|(?:\\[.+] )?\\w{1,16} has disbanded the party!|You left the party.)$";
     private String autoChatSwapperPartyStatus2 = "^(?:You have joined (?:\\[.+] )?(?:.*)|Party Members(?:\\[.+] )?\\w{1,100}|(?:\\[.+] )?\\w{1,100} joined the(?:.*) party(?:.*))$";


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes
![image](https://github.com/user-attachments/assets/32c700ce-08cb-4403-b6d1-9d0ef0483538)


## How to test
<!-- Provide steps to test this PR -->
`/msg <username> <message>`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
fix short PM message names changing guild list
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->