### PR TITLE
Fix autofriend

### DIFF
--- a/src/main/java/org/polyfrost/hytils/handlers/language/LanguageData.java
+++ b/src/main/java/org/polyfrost/hytils/handlers/language/LanguageData.java
@@ -34,7 +34,7 @@ public class LanguageData {
      */
     private String autoQueuePrefixGlobal = "^(?:You died! .+|YOU DIED! .+|You have been eliminated!|You won! .+|YOU WON! .+)$";
 
-    private String autoFriendPattern = "Friend request from (?<name>.+)\\[ACCEPT] - \\[DENY] - \\[IGNORE].*";
+    private String autoFriendPattern = "Friend request from (?<name>.+)\\[ACCEPT] - \\[DENY] - \\[BLOCK].*";
     private String autoAfkReplyPattern = "^From (\\[.+?] )?(.+?): .+$";
 
     private String chatCleanerKarmaMessages = "^\\+(?<karma>\\d)+ Karma!$";


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Possibly along with the Social Update, Hypixel changed a friend request message, which broke the autofriend option.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
fix autofriend
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->