### PR TITLE
Update AutoGG.java (bug fix)

### DIFF
--- a/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoGG.java
+++ b/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoGG.java
@@ -44,6 +44,7 @@ public class AutoGG implements ChatReceiveModule {
         Multithreading.schedule(() -> UChat.say("/ac " + HytilsConfig.ggMessage), (long) (HytilsConfig.autoGGFirstPhraseDelay * 1000), TimeUnit.MILLISECONDS);
         if (HytilsConfig.autoGGSecondMessage)
             Multithreading.schedule(() -> UChat.say("/ac " + HytilsConfig.ggMessage2), (long) ((HytilsConfig.autoGGSecondPhraseDelay + HytilsConfig.autoGGFirstPhraseDelay) * 1000), TimeUnit.MILLISECONDS);
+        matchFound = false;
     }
 
     private boolean hasGameEnded(String message) {


### PR DESCRIPTION
fixed a bug where autogg messages would only trigger on the first game after you load up Minecraft

---------NOTE----------
there's now a bug where it tries to send twice, I'm looking into it

## Description
I reset the matchFound bool after it says a message so that it can say the message again the next time a game ends

## Release Notes
Only added one line of code in 
src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoGG.java