### PR TITLE
Update AutoGG.java (bug fix)

### DIFF
--- a/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoGG.java
+++ b/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoGG.java
@@ -40,17 +40,25 @@ public class AutoGG implements ChatReceiveModule {
     @Override
     public void onMessageReceived(@NotNull ClientChatReceivedEvent event) {
         String message = EnumChatFormatting.getTextWithoutFormattingCodes(event.message.getUnformattedText());
-        if (!hasGameEnded(message)) return;
-        Multithreading.schedule(() -> UChat.say("/ac " + HytilsConfig.ggMessage), (long) (HytilsConfig.autoGGFirstPhraseDelay * 1000), TimeUnit.MILLISECONDS);
-        if (HytilsConfig.autoGGSecondMessage)
-            Multithreading.schedule(() -> UChat.say("/ac " + HytilsConfig.ggMessage2), (long) ((HytilsConfig.autoGGSecondPhraseDelay + HytilsConfig.autoGGFirstPhraseDelay) * 1000), TimeUnit.MILLISECONDS);
+        if (!hasGameEnded(message)) {
+            return;
+        }
+
+        if (!matchFound) {
+            matchFound = true;
+            Multithreading.schedule(() -> UChat.say("/ac " + HytilsConfig.ggMessage), (long) (HytilsConfig.autoGGFirstPhraseDelay * 1000), TimeUnit.MILLISECONDS);
+            if (HytilsConfig.autoGGSecondMessage) {
+                Multithreading.schedule(() -> UChat.say("/ac " + HytilsConfig.ggMessage2), (long) ((HytilsConfig.autoGGSecondPhraseDelay + HytilsConfig.autoGGFirstPhraseDelay) * 1000), TimeUnit.MILLISECONDS);
+            }
+            // Schedule the reset of matchFound after the second message has been sent
+            Multithreading.schedule(() -> matchFound = false, (long) ((HytilsConfig.autoGGSecondPhraseDelay + HytilsConfig.autoGGFirstPhraseDelay) * 1000) + 5000, TimeUnit.MILLISECONDS);
+        }
     }
 
     private boolean hasGameEnded(String message) {
         if (!matchFound && !PatternHandler.INSTANCE.gameEnd.isEmpty()) {
             for (Pattern triggers : PatternHandler.INSTANCE.gameEnd) {
                 if (triggers.matcher(message).matches()) {
-                    matchFound = true;
                     return true;
                 }
             }
@@ -75,3 +83,4 @@ public class AutoGG implements ChatReceiveModule {
         return 3;
     }
 }
+


### PR DESCRIPTION
## Description
Its messy, but this fixes a bug where The autogg function would only run once on the first game you played when the game was loaded. It now sets the matchFound bool to false after 5 seconds. that's the longest you can set the delay for autogg messages. this has worked perfectly for me, even if you don't have a second autogg message turned on.

only contents of this file have been modified
src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoGG.java