### PR TITLE
add DISASTERS to hide food

### DIFF
--- a/src/main/java/org/polyfrost/hytils/mixin/GuiIngameForgeMixin_HideHotbar.java
+++ b/src/main/java/org/polyfrost/hytils/mixin/GuiIngameForgeMixin_HideHotbar.java
@@ -96,6 +96,10 @@ public class GuiIngameForgeMixin_HideHotbar {
                     if (gameMode.contains("CAPTURE")) {
                         break;
                     }
+                case PROTOTYPE:
+                    if (!gameMode.contains("DISASTERS")) {
+                        break;
+                    }
                 case BEDWARS:
                 case MURDER_MYSTERY:
                 case HOUSING:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
New gamemode DISASTERS does not use food (i think)

i did this in github web

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
play disasters with the hide hotbar thing on

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Add hiding hunger bars while in Disasters to Hide HUD Elements
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->