### PR TITLE
[BUGFIX] Fix armor still being hidden when hytils is disabled

### DIFF
--- a/src/main/java/org/polyfrost/hytils/mixin/LayerArmorBaseMixin_HideIngameArmour.java
+++ b/src/main/java/org/polyfrost/hytils/mixin/LayerArmorBaseMixin_HideIngameArmour.java
@@ -21,6 +21,7 @@ package org.polyfrost.hytils.mixin;
 import cc.polyfrost.oneconfig.utils.hypixel.HypixelUtils;
 import cc.polyfrost.oneconfig.utils.hypixel.LocrawInfo;
 import cc.polyfrost.oneconfig.utils.hypixel.LocrawUtil;
+import org.polyfrost.hytils.HytilsReborn;
 import org.polyfrost.hytils.config.HytilsConfig;
 import net.minecraft.client.renderer.entity.layers.LayerArmorBase;
 import net.minecraft.entity.EntityLivingBase;
@@ -48,7 +49,7 @@ public abstract class LayerArmorBaseMixin_HideIngameArmour {
 
     @Unique
     private static boolean hytils$shouldCancel(ItemStack itemStack) {
-        if (!HytilsConfig.hideArmor || itemStack == null || !HypixelUtils.INSTANCE.isHypixel()) return false;
+        if (!HytilsConfig.hideArmor || itemStack == null || !HypixelUtils.INSTANCE.isHypixel() || !HytilsReborn.INSTANCE.getConfig().enabled) return false;
         final LocrawInfo locraw = LocrawUtil.INSTANCE.getLocrawInfo();
         final Item item = itemStack.getItem();
         if (locraw != null) {


### PR DESCRIPTION
## Description
Don't hide armor when hytils reborn is disabled in oneconfig

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #114 

## How to test
<!-- Provide steps to test this PR -->
#### On version before PR:
1. Join hypixel duels game with hide armor and hytils reborn enabled
2. Disable hytils reborn in oneconfig
3. See that armor is still hidden
#### On this version:
1. Join hypixel duels game with hide armor and hytils reborn enabled
2. Disable hytils reborn in oneconfig
3. See that armor is no longer hidden
4. Turn hytils back on
5. See that armor is hidden again!
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
fix armor being hidden even when hytils reborn is disabled
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No documentation changes are required