### PR TITLE
Disable the mod's features when it is disabled in oneconfig

### DIFF
--- a/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoQueue.java
+++ b/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoQueue.java
@@ -38,7 +38,7 @@ public class AutoQueue implements ChatReceiveModule {
 
     @Override
     public void onMessageReceived(@NotNull ClientChatReceivedEvent event) {
-        if (!HytilsConfig.autoQueue) {
+        if (!HytilsConfig.autoQueue || !HytilsReborn.INSTANCE.getConfig().enabled) {
             return;
         }
 

--- a/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoVictory.java
+++ b/src/main/java/org/polyfrost/hytils/handlers/chat/modules/triggers/AutoVictory.java
@@ -49,17 +49,15 @@ public class AutoVictory implements ChatReceiveResetModule {
     @Override
     public void onMessageReceived(@NotNull ClientChatReceivedEvent event) {
         String unformattedText = UTextComponent.Companion.stripFormatting(event.message.getUnformattedText());
-        if (!PatternHandler.INSTANCE.gameEnd.isEmpty()) {
-            if (!victoryDetected) { // prevent victories being detected twice
-                Multithreading.runAsync(() -> { //run this async as getting from the API normally would freeze minecraft
-                    for (Pattern triggers : PatternHandler.INSTANCE.gameEnd) {
-                        if (triggers.matcher(unformattedText).matches()) {
-                            doNotification();
-                            return;
-                        }
+        if (!PatternHandler.INSTANCE.gameEnd.isEmpty() && !victoryDetected) { // prevent victories being detected twice
+            Multithreading.runAsync(() -> { //run this async as getting from the API normally would freeze minecraft
+                for (Pattern triggers : PatternHandler.INSTANCE.gameEnd) {
+                    if (triggers.matcher(unformattedText).matches()) {
+                        doNotification();
+                        return;
                     }
-                });
-            }
+                }
+            });
         }
     }
 
@@ -75,53 +73,55 @@ public class AutoVictory implements ChatReceiveResetModule {
 
     private void doNotification() {
         victoryDetected = true;
-        if (HytilsConfig.autoGetGEXP) {
-            if (!HytilsConfig.gexpMode) {
+        if (HytilsReborn.INSTANCE.getConfig().enabled) {
+            if (HytilsConfig.autoGetGEXP) {
+                if (!HytilsConfig.gexpMode) {
+                    try {
+                        if (HypixelAPIUtils.getGEXP()) {
+                            Notifications.INSTANCE
+                                .send(
+                                    HytilsReborn.MOD_NAME,
+                                    "You currently have " + HypixelAPIUtils.gexp + " daily guild EXP."
+                                );
+                            return;
+                        }
+                    } catch (Exception ignored) {
+
+                    }
+                    Notifications.INSTANCE
+                        .send(HytilsReborn.MOD_NAME, "There was a problem trying to get your GEXP.");
+                } else {
+                    try {
+                        if (HypixelAPIUtils.getWeeklyGEXP()) {
+                            Notifications.INSTANCE
+                                .send(
+                                    HytilsReborn.MOD_NAME,
+                                    "You currently have " + HypixelAPIUtils.gexp + " weekly guild EXP."
+                                );
+                            return;
+                        }
+                    } catch (Exception ignored) {
+
+                    }
+                    Notifications.INSTANCE
+                        .send(HytilsReborn.MOD_NAME, "There was a problem trying to get your GEXP.");
+                }
+            }
+            if (isSupportedMode(getLocraw()) && HytilsConfig.autoGetWinstreak) {
                 try {
-                    if (HypixelAPIUtils.getGEXP()) {
-                        Notifications.INSTANCE
-                            .send(
-                                HytilsReborn.MOD_NAME,
-                                "You currently have " + HypixelAPIUtils.gexp + " daily guild EXP."
-                            );
+                    if (HypixelAPIUtils.getWinstreak()) {
+                        Notifications.INSTANCE.send(
+                            HytilsReborn.MOD_NAME,
+                            "You currently have a " + HypixelAPIUtils.winstreak + " winstreak."
+                        );
                         return;
                     }
                 } catch (Exception ignored) {
 
                 }
                 Notifications.INSTANCE
-                    .send(HytilsReborn.MOD_NAME, "There was a problem trying to get your GEXP.");
-            } else {
-                try {
-                    if (HypixelAPIUtils.getWeeklyGEXP()) {
-                        Notifications.INSTANCE
-                            .send(
-                                HytilsReborn.MOD_NAME,
-                                "You currently have " + HypixelAPIUtils.gexp + " weekly guild EXP."
-                            );
-                        return;
-                    }
-                } catch (Exception ignored) {
-
-                }
-                Notifications.INSTANCE
-                    .send(HytilsReborn.MOD_NAME, "There was a problem trying to get your GEXP.");
+                    .send(HytilsReborn.MOD_NAME, "There was a problem trying to get your winstreak.");
             }
-        }
-        if (isSupportedMode(getLocraw()) && HytilsConfig.autoGetWinstreak) {
-            try {
-                if (HypixelAPIUtils.getWinstreak()) {
-                    Notifications.INSTANCE.send(
-                        HytilsReborn.MOD_NAME,
-                        "You currently have a " + HypixelAPIUtils.winstreak + " winstreak."
-                    );
-                    return;
-                }
-            } catch (Exception ignored) {
-
-            }
-            Notifications.INSTANCE
-                .send(HytilsReborn.MOD_NAME, "There was a problem trying to get your winstreak.");
         }
     }
 

--- a/src/main/java/org/polyfrost/hytils/handlers/general/AutoStart.java
+++ b/src/main/java/org/polyfrost/hytils/handlers/general/AutoStart.java
@@ -34,7 +34,7 @@ public class AutoStart {
     @SubscribeEvent
     public void tick(TickEvent.ClientTickEvent event) {
         if (Minecraft.getMinecraft().currentScreen instanceof GuiMainMenu && HytilsReborn.INSTANCE.isLoadedCall()) {
-            if (HytilsConfig.autoStart) {
+            if (HytilsConfig.autoStart && HytilsReborn.INSTANCE.getConfig().enabled) {
                 FMLClientHandler.instance().connectToServer(
                     new GuiMultiplayer(Minecraft.getMinecraft().currentScreen),
                     new ServerData("hypixel", "hypixel.net", false)

--- a/src/main/java/org/polyfrost/hytils/mixin/LayerArmorBaseMixin_HideIngameArmour.java
+++ b/src/main/java/org/polyfrost/hytils/mixin/LayerArmorBaseMixin_HideIngameArmour.java
@@ -21,6 +21,7 @@ package org.polyfrost.hytils.mixin;
 import cc.polyfrost.oneconfig.utils.hypixel.HypixelUtils;
 import cc.polyfrost.oneconfig.utils.hypixel.LocrawInfo;
 import cc.polyfrost.oneconfig.utils.hypixel.LocrawUtil;
+import org.polyfrost.hytils.HytilsReborn;
 import org.polyfrost.hytils.config.HytilsConfig;
 import net.minecraft.client.renderer.entity.layers.LayerArmorBase;
 import net.minecraft.entity.EntityLivingBase;
@@ -48,7 +49,7 @@ public abstract class LayerArmorBaseMixin_HideIngameArmour {
 
     @Unique
     private static boolean hytils$shouldCancel(ItemStack itemStack) {
-        if (!HytilsConfig.hideArmor || itemStack == null || !HypixelUtils.INSTANCE.isHypixel()) return false;
+        if (!HytilsConfig.hideArmor || itemStack == null || !HypixelUtils.INSTANCE.isHypixel() || !HytilsReborn.INSTANCE.getConfig().enabled) return false;
         final LocrawInfo locraw = LocrawUtil.INSTANCE.getLocrawInfo();
         final Item item = itemStack.getItem();
         if (locraw != null) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Disables the mod's features when it is disabled in oneconfig
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #114 

## How to test
<!-- Provide steps to test this PR -->
See how the mod's features no longer do anything when it is disabled in oneconfig
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
disable the mod's features when it is disabled via oneconfig
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No documentation changes needed

## Checklist
- [x] Hide Armor
- [x] Auto Queue (couldn't get it working with the stable version, so I can't test this)
- [x]  Auto Start
- [x] Automatically Check GEXP
- [x] Automatically Check Winstreak
- [ ] Notify Mining Fatigue
- [ ] Auto GG
- [ ] Anti GG
- [ ] Auto GL
- [ ] Anti GL
- [ ] Auto Friend
- [ ] Auto Party Warp Confirm
- [ ] Auto Reply When AFK
- [ ] Game Status Restyle
- [ ] Player Count Before Player Name
- [ ] Player Count on Player Leave
- [ ] Player Count Padding
- [ ] Trim Line Separators
- [ ] Clean Line Separators
- [ ] White Chat
- [ ] White PMs
- [ ] Colored Friend/Guild Statuses
- [ ] Cleaner Game Counter
- [ ] Short Channel Names
- [ ] Short PM Channel Names
- [ ] Party Chat Swapper
- [ ] Notify When Kicked From Game
- [ ] Broadcast Achievements
- [ ] Broadcast Levelup
- [ ] Guild Welcome Message
- [ ] Thank Watchdog
- [ ] All the toggles in toggle subsection in chat section (I am not listing them all)
- [ ] Auto WB
- [ ] Highlight Friends in tab
- [ ] Highlight Self in Tab
- [ ] Hide NPCs in Tab
- [ ] Hide Guild Tags in Tab
- [ ] Hide Player Ranks in Tab
- [ ] Hide Ping in Tab
- [ ] Cleaner Tab in Skyblock
- [ ] Hide Advertisements in Tab
- [ ] Hide HUD Elements
- [ ] Hardcore Hearts
- [ ] Hide Game Ending Titles
- [ ] Hide Advertisements in Bossbars
- [ ] Hide Game Starting Titles
- [ ] Hide Countdown Titles
- [ ] Hide Useless Game Nametags
- [ ] Notify When Blocks Run Out
- [ ] Arcade/Middle Waypoint Beacon in MiniWalls
- [ ] Arcade/Hide Arcade Cosmetics
- [ ] BedWars/Colored Beds
- [ ] BedWars/Height Overlay
- [ ] Dropper/Hide Actionbar
- [ ] Dropper/Mute Hurt Sounds
- [ ] Duels/Lower Render Distance in Sumo
- [ ] Duels/Hide Duels Cosmetics
- [ ] Housing/Mute Music
- [ ] Housing/Hide Actionbar
- [ ] Pit/Lag Reducer
- [ ] Skyblock/Remove Non-NPCs
- [ ] Skywars/Highlight Opened Chests
- [ ] UHC/Overlay
- [ ] UHC/Middle Waypoint
- [ ] Hide Lobby NPCs
- [ ] Hide Useless Lobby Nametags
- [ ] Hide Lobby Bossbars
- [ ] All Lobby sound settings (so many!)
- [ ] Remove Limbo AFK Title
- [ ] Limbo Limiter
- [ ] Limbo PM Ding