### PR TITLE
Update regex pattern for join / leave messages in fallback regex

### DIFF
--- a/src/main/java/org/polyfrost/hytils/handlers/language/LanguageData.java
+++ b/src/main/java/org/polyfrost/hytils/handlers/language/LanguageData.java
@@ -70,8 +70,8 @@ public class LanguageData {
     private String levelUpPattern = "You are now Hypixel Level (?<level>\\d+)!";
     private String guildPlayerJoinPattern = "^(?:\\[.*] )?(?<player>\\S{1,16}) joined the guild!$";
 
-    private String chatRestylerGameJoinStyle = "^\u00a7r\u00a7e\u00a7r\u00a7(?<color>[\\da-f])(?:\u00a7k)?(?<player>\\w{1,16})\u00a7r\u00a7r\u00a7r\u00a7e has joined (?<amount>.+)!\u00a7r\u00a7e\u00a7r$";
-    private String chatRestylerGameLeaveStyle = "^\u00a7r\u00a7e\u00a7r\u00a7(?<color>[\\da-f])(?:\u00a7k)?(?<player>\\w{1,16})\u00a7r\u00a7r\u00a7r\u00a7e has quit!\u00a7r\u00a7e\u00a7r$";
+    private String chatRestylerGameJoinStyle = "^\u00a7r\u00a7e\u00a7r\u00a7(?<color>[\\da-f])(?:\u00a7[kr])*(?<player>\\w{1,16})\u00a7r\u00a7r\u00a7r\u00a7e has joined (?<amount>.+)!\u00a7r\u00a7e\u00a7r$";
+    private String chatRestylerGameLeaveStyle = "^\u00a7r\u00a7e\u00a7r\u00a7(?<color>[\\da-f])(?:\u00a7[kr])*(?<player>\\w{1,16})\u00a7r\u00a7r\u00a7r\u00a7e has quit!\u00a7r\u00a7e\u00a7r$";
     private String chatRestylerGameStartCounterStyle = "^(?<title>(The game starts in|Cages open in:|You will respawn in|The Murderer gets their sword in|You get your sword in|The alpha infected will be chosen in|Kill contracts will be issued in|The Murderers get their swords in|You can start shooting in|The door opens in)) (?<time>\\d{1,3}) (?<unit>(seconds?!))(?: .\\d+.|)$";
     private String chatRestylerGameStartCounterOutputStyle = "^\u00a7e\u00a7l\\* \u00a7a(The game starts in|Cages open in:|You will respawn in|The Murderer gets their sword in|You get your sword in|The alpha infected will be chosen in|Kill contracts will be issued in|The Murderers get their swords in|You can start shooting in|The door opens in) \u00a7b\u00a7l\\d{1,3} \u00a7aseconds?!\u00a7r$";
     private String chatRestylerFormattedPaddingPattern = "\\(\u00a7r\u00a7b(\\d{1,2})\u00a7r\u00a7r\u00a7r\u00a7e/\u00a7r\u00a7b(\\d{1,3})\u00a7r\u00a7r\u00a7r\u00a7e\\)";


### PR DESCRIPTION
## Description
Updates the regex pattern to match cases where the obfuscated code (§k) is repeated as §r§k.
Only affects the fallback regex in the code.

## Related Issue(s)
None

## How to test
1. Go to `src/main/java/org/polyfrost/hytils/handlers/language/LanguageHandler.java`
2. Comment out lines 50 - 54 to prevent the mod from making the API calls for current regex
3. Compile and run the mod

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
fix join/leave messages not getting restyled for players with hidden names
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->